### PR TITLE
Calculate movie aspect ratio using vertices

### DIFF
--- a/UnleashedRecomp/api/SWA/Movie/MovieDisplayer.h
+++ b/UnleashedRecomp/api/SWA/Movie/MovieDisplayer.h
@@ -7,8 +7,23 @@ namespace SWA
     class CMovieDisplayer : public Hedgehog::Universe::CUpdateUnit, public Hedgehog::Mirage::CRenderable
     {
     public:
+        struct SVertexData
+        {
+            be<float> X;
+            be<float> Y;
+            be<float> Z;
+            be<float> U;
+            be<float> V;
+        };
+
         SWA_INSERT_PADDING(0x04);
         be<uint32_t> m_MovieWidth;
         be<uint32_t> m_MovieHeight;
+        SWA_INSERT_PADDING(0x74);
+        SVertexData m_TopLeft;
+        SVertexData m_TopRight;
+        SVertexData m_BottomRight;
+        SVertexData m_BottomLeft;
+        SWA_INSERT_PADDING(0xF0);
     };
 }

--- a/UnleashedRecomp/patches/video_patches.cpp
+++ b/UnleashedRecomp/patches/video_patches.cpp
@@ -8,15 +8,19 @@ using SVertexData = SWA::Sequence::Utility::CPlayMovieWrapper::CRender::SVertexD
 PPC_FUNC_IMPL(__imp__sub_82AE30D8);
 PPC_FUNC(sub_82AE30D8)
 {
-    auto movieWidth = *(be<float>*)g_memory.Translate(ctx.r4.u32 - 0x10);
-    auto movieHeight = *(be<float>*)g_memory.Translate(ctx.r4.u32 - 0x0C);
-    auto movieAspectRatio = movieWidth / movieHeight;
-    auto windowAspectRatio = (float)GameWindow::s_width / (float)GameWindow::s_height;
+    auto pViewportWidth = (be<uint32_t>*)g_memory.Translate(ctx.r4.u32 + 0x14);
+    auto pViewportHeight = (be<uint32_t>*)g_memory.Translate(ctx.r4.u32 + 0x18);
 
     auto pTopLeft = (SVertexData*)g_memory.Translate(ctx.r4.u32 + 0x6C);
     auto pTopRight = (SVertexData*)g_memory.Translate(ctx.r4.u32 + 0x6C + sizeof(SVertexData));
     auto pBottomRight = (SVertexData*)g_memory.Translate(ctx.r4.u32 + 0x6C + sizeof(SVertexData) * 2);
     auto pBottomLeft = (SVertexData*)g_memory.Translate(ctx.r4.u32 + 0x6C + sizeof(SVertexData) * 3);
+
+    auto quadWidth = std::fabs(pTopRight->X - pTopLeft->X) * ((float)*pViewportWidth / 2);
+    auto quadHeight = std::fabs(pTopLeft->Y - pBottomLeft->Y) * ((float)*pViewportHeight / 2);
+
+    auto movieAspectRatio = quadWidth / quadHeight;
+    auto windowAspectRatio = (float)GameWindow::s_width / (float)GameWindow::s_height;
 
     auto a = -1.00078f;
     auto b = 1.00139f;


### PR DESCRIPTION
This fixes movies using `SWA::CMovieDisplayer` pulling the movie width and height from the wrong fields due to the hook expecting `SWA::Sequence::Utility::CPlayMovieWrapper`.

The movie aspect ratio is now determined by using the vertices and original viewport dimensions, allowing the Werehog transformation cutscene to render properly again.

Before:
![image](https://github.com/user-attachments/assets/bbc692cf-cbe5-4f7f-a761-b749da48f72d)

After:
![image](https://github.com/user-attachments/assets/346ae727-58d2-4e39-bdf3-97354c283352)
![image](https://github.com/user-attachments/assets/6a27ce8c-9e7c-4a2c-b9db-4e54dfcafe41)

Addresses https://github.com/hedge-dev/UnleashedRecomp/issues/81.