### PR TITLE
Fix start button closing pause menu behind options and achievements menus

### DIFF
--- a/UnleashedRecomp/hid/hid.cpp
+++ b/UnleashedRecomp/hid/hid.cpp
@@ -5,9 +5,16 @@
 hid::detail::EInputDevice hid::detail::g_inputDevice;
 hid::detail::EInputDevice hid::detail::g_inputDeviceController;
 
+uint16_t hid::detail::g_prohibitedButtons;
+
 void hid::Init()
 {
     detail::Init();
+}
+
+void hid::SetProhibitedButtons(uint16_t wButtons)
+{
+    hid::detail::g_prohibitedButtons = wButtons;
 }
 
 uint32_t hid::GetState(uint32_t dwUserIndex, XAMINPUT_STATE* pState)

--- a/UnleashedRecomp/hid/hid.h
+++ b/UnleashedRecomp/hid/hid.h
@@ -5,6 +5,7 @@ union SDL_Event;
 namespace hid
 {
     void Init();
+    void SetProhibitedButtons(uint16_t wButtons);
 
     uint32_t GetState(uint32_t dwUserIndex, XAMINPUT_STATE* pState);
     uint32_t SetState(uint32_t dwUserIndex, XAMINPUT_VIBRATION* pVibration);

--- a/UnleashedRecomp/hid/hid_detail.h
+++ b/UnleashedRecomp/hid/hid_detail.h
@@ -13,6 +13,8 @@ namespace hid::detail
     extern EInputDevice g_inputDevice;
     extern EInputDevice g_inputDeviceController;
 
+    extern uint16_t g_prohibitedButtons;
+
     void Init();
 
     uint32_t GetState(uint32_t dwUserIndex, XAMINPUT_STATE* pState);

--- a/UnleashedRecomp/kernel/xam.cpp
+++ b/UnleashedRecomp/kernel/xam.cpp
@@ -406,23 +406,19 @@ SWA_API uint32_t XamInputGetState(uint32_t userIndex, uint32_t flags, XAMINPUT_S
 
     uint32_t result = hid::GetState(userIndex, state);
 
-    auto keyboardState = SDL_GetKeyboardState(NULL);
-
-    if (GameWindow::s_isFocused && !keyboardState[SDL_SCANCODE_LALT])
+    if (GameWindow::s_isFocused)
     {
-        if (keyboardState[SDL_SCANCODE_W])
-            state->Gamepad.wButtons |= XAMINPUT_GAMEPAD_Y;
-        if (keyboardState[SDL_SCANCODE_A])
-            state->Gamepad.wButtons |= XAMINPUT_GAMEPAD_X;
-        if (keyboardState[SDL_SCANCODE_S])
-            state->Gamepad.wButtons |= XAMINPUT_GAMEPAD_A;
-        if (keyboardState[SDL_SCANCODE_D])
-            state->Gamepad.wButtons |= XAMINPUT_GAMEPAD_B;
+        auto keyboardState = SDL_GetKeyboardState(NULL);
 
-        if (keyboardState[SDL_SCANCODE_Q])
-            state->Gamepad.wButtons |= XAMINPUT_GAMEPAD_LEFT_SHOULDER;
-        if (keyboardState[SDL_SCANCODE_E])
-            state->Gamepad.wButtons |= XAMINPUT_GAMEPAD_RIGHT_SHOULDER;
+        if (keyboardState[SDL_SCANCODE_UP])
+            state->Gamepad.sThumbLY = 32767;
+        if (keyboardState[SDL_SCANCODE_DOWN])
+            state->Gamepad.sThumbLY = -32768;
+        if (keyboardState[SDL_SCANCODE_LEFT])
+            state->Gamepad.sThumbLX = -32768;
+        if (keyboardState[SDL_SCANCODE_RIGHT])
+            state->Gamepad.sThumbLX = 32767;
+
         if (keyboardState[SDL_SCANCODE_1])
             state->Gamepad.bLeftTrigger = 0xFF;
         if (keyboardState[SDL_SCANCODE_3])
@@ -430,27 +426,34 @@ SWA_API uint32_t XamInputGetState(uint32_t userIndex, uint32_t flags, XAMINPUT_S
 
         if (keyboardState[SDL_SCANCODE_I])
             state->Gamepad.wButtons |= XAMINPUT_GAMEPAD_DPAD_UP;
-        if (keyboardState[SDL_SCANCODE_J])
-            state->Gamepad.wButtons |= XAMINPUT_GAMEPAD_DPAD_LEFT;
         if (keyboardState[SDL_SCANCODE_K])
             state->Gamepad.wButtons |= XAMINPUT_GAMEPAD_DPAD_DOWN;
+        if (keyboardState[SDL_SCANCODE_J])
+            state->Gamepad.wButtons |= XAMINPUT_GAMEPAD_DPAD_LEFT;
         if (keyboardState[SDL_SCANCODE_L])
             state->Gamepad.wButtons |= XAMINPUT_GAMEPAD_DPAD_RIGHT;
 
-        if (keyboardState[SDL_SCANCODE_UP])
-            state->Gamepad.sThumbLY = 32767;
-        if (keyboardState[SDL_SCANCODE_LEFT])
-            state->Gamepad.sThumbLX = -32768;
-        if (keyboardState[SDL_SCANCODE_DOWN])
-            state->Gamepad.sThumbLY = -32768;
-        if (keyboardState[SDL_SCANCODE_RIGHT])
-            state->Gamepad.sThumbLX = 32767;
-
-        if (keyboardState[SDL_SCANCODE_RETURN])
+        if (keyboardState[SDL_SCANCODE_RETURN] && !keyboardState[SDL_SCANCODE_LALT])
             state->Gamepad.wButtons |= XAMINPUT_GAMEPAD_START;
         if (keyboardState[SDL_SCANCODE_BACKSPACE])
             state->Gamepad.wButtons |= XAMINPUT_GAMEPAD_BACK;
+
+        if (keyboardState[SDL_SCANCODE_Q])
+            state->Gamepad.wButtons |= XAMINPUT_GAMEPAD_LEFT_SHOULDER;
+        if (keyboardState[SDL_SCANCODE_E])
+            state->Gamepad.wButtons |= XAMINPUT_GAMEPAD_RIGHT_SHOULDER;
+
+        if (keyboardState[SDL_SCANCODE_S])
+            state->Gamepad.wButtons |= XAMINPUT_GAMEPAD_A;
+        if (keyboardState[SDL_SCANCODE_D])
+            state->Gamepad.wButtons |= XAMINPUT_GAMEPAD_B;
+        if (keyboardState[SDL_SCANCODE_A])
+            state->Gamepad.wButtons |= XAMINPUT_GAMEPAD_X;
+        if (keyboardState[SDL_SCANCODE_W])
+            state->Gamepad.wButtons |= XAMINPUT_GAMEPAD_Y;
     }
+
+    state->Gamepad.wButtons &= ~hid::detail::g_prohibitedButtons;
 
     ByteSwapInplace(state->Gamepad.wButtons);
     ByteSwapInplace(state->Gamepad.sThumbLX);

--- a/UnleashedRecomp/ui/achievement_menu.cpp
+++ b/UnleashedRecomp/ui/achievement_menu.cpp
@@ -14,6 +14,7 @@
 #include <res/images/common/general_window.dds.h>
 #include <res/images/common/select_fill.dds.h>
 #include <gpu/imgui/imgui_snapshot.h>
+#include <hid/hid.h>
 
 constexpr double HEADER_CONTAINER_INTRO_MOTION_START = 0;
 constexpr double HEADER_CONTAINER_INTRO_MOTION_END = 15;
@@ -815,6 +816,8 @@ void AchievementMenu::Open()
 
     ResetSelection();
     Game_PlaySound("sys_actstg_pausewinopen");
+
+    hid::SetProhibitedButtons(XAMINPUT_GAMEPAD_START);
 }
 
 void AchievementMenu::Close()
@@ -823,6 +826,8 @@ void AchievementMenu::Close()
     {
         g_appearTime = ImGui::GetTime();
         g_isClosing = true;
+
+        hid::SetProhibitedButtons(0);
     }
 
     ButtonGuide::Close();

--- a/UnleashedRecomp/ui/options_menu.cpp
+++ b/UnleashedRecomp/ui/options_menu.cpp
@@ -8,6 +8,7 @@
 #include <gpu/imgui/imgui_common.h>
 #include <gpu/video.h>
 #include <gpu/imgui/imgui_snapshot.h>
+#include <hid/hid.h>
 #include <kernel/heap.h>
 #include <kernel/memory.h>
 #include <locale/locale.h>
@@ -1232,6 +1233,8 @@ void OptionsMenu::Open(bool isPause, SWA::EMenuType pauseMenuType)
     
     ButtonGuide::Open(buttons);
     ButtonGuide::SetSideMargins(250);
+
+    hid::SetProhibitedButtons(XAMINPUT_GAMEPAD_START);
 }
 
 void OptionsMenu::Close()
@@ -1244,6 +1247,8 @@ void OptionsMenu::Close()
 
         ButtonGuide::Close();
         Config::Save();
+
+        hid::SetProhibitedButtons(0);
     }
 
     // Skip Miles Electric animation at main menu.


### PR DESCRIPTION
This PR implements "button prohibition" which allows any combination of the face buttons to be blocked from being accepted as inputs.

I couldn't find where the game itself handled the start button input for the pause menu, so this seemed like a more logical approach and can be used for more inputs if necessary.