### PR TITLE
Added scheme handler for Linux Flatpak

### DIFF
--- a/flatpak/io.github.hedge_dev.unleashedrecomp.desktop
+++ b/flatpak/io.github.hedge_dev.unleashedrecomp.desktop
@@ -5,3 +5,4 @@ Type=Application
 Icon=io.github.hedge_dev.unleashedrecomp
 Categories=Game;
 Comment=Static recompilation of Sonic Unleashed.
+MimeType=x-scheme-handler/unleashedrecomp


### PR DESCRIPTION
This allows Linux users to start the application by just calling `unleashedrecomp:/`.

This will be useful when the user or external application wants to start the application while in another sandbox.