### PR TITLE
Fix PS3 time of day transition aspect ratio and outro animation

### DIFF
--- a/UnleashedRecomp/api/SWA/HUD/Loading/Loading.h
+++ b/UnleashedRecomp/api/SWA/HUD/Loading/Loading.h
@@ -21,14 +21,20 @@ namespace SWA
     {
     public:
         SWA_INSERT_PADDING(0xD8);
-        be<uint32_t> m_pUnk;
+        be<uint32_t> m_FieldD8;
         SWA_INSERT_PADDING(0x3C);
         Chao::CSD::RCPtr<Chao::CSD::CScene> m_rcNightToDay;
         SWA_INSERT_PADDING(0x0C);
         be<uint32_t> m_IsVisible;
         SWA_INSERT_PADDING(0x0C);
         be<ELoadingDisplayType> m_LoadingDisplayType;
-        SWA_INSERT_PADDING(0x65);
+        SWA_INSERT_PADDING(0x61);
         bool m_IsNightToDay;
     };
+
+    SWA_ASSERT_OFFSETOF(CLoading, m_FieldD8, 0xD8);
+    SWA_ASSERT_OFFSETOF(CLoading, m_rcNightToDay, 0x118);
+    SWA_ASSERT_OFFSETOF(CLoading, m_IsVisible, 0x12C);
+    SWA_ASSERT_OFFSETOF(CLoading, m_LoadingDisplayType, 0x13C);
+    SWA_ASSERT_OFFSETOF(CLoading, m_IsNightToDay, 0x1A1);
 }

--- a/UnleashedRecomp/patches/aspect_ratio_patches.cpp
+++ b/UnleashedRecomp/patches/aspect_ratio_patches.cpp
@@ -370,7 +370,7 @@ static const ankerl::unordered_dense::map<XXH64_hash_t, CsdModifier> g_modifiers
     { HashStr("ui_gate/footer/status_footer"), { ALIGN_BOTTOM } },
     { HashStr("ui_gate/header/status_title"), { ALIGN_TOP | OFFSET_SCALE_LEFT, 652.0f } },
     { HashStr("ui_gate/header/status_title/title_bg/center"), { ALIGN_TOP | EXTEND_LEFT } },
-    { HashStr("ui_gate/header/status_title/title_bg/center/h_light"), { ALIGN_TOP | EXTEND_LEFT} },
+    { HashStr("ui_gate/header/status_title/title_bg/center/h_light"), { ALIGN_TOP | EXTEND_LEFT } },
     { HashStr("ui_gate/header/status_title/title_bg/right"), { ALIGN_TOP | STORE_RIGHT_CORNER } },
     { HashStr("ui_gate/window/window_bg"), { STRETCH } },
 
@@ -383,12 +383,18 @@ static const ankerl::unordered_dense::map<XXH64_hash_t, CsdModifier> g_modifiers
     { HashStr("ui_itemresult/main/iresult_title"), { ALIGN_TOP } },
     { HashStr("ui_itemresult/main/iresult_title"), { ALIGN_TOP | OFFSET_SCALE_LEFT, 688.0f } },
     { HashStr("ui_itemresult/main/iresult_title/title_bg/center"), { ALIGN_TOP | EXTEND_LEFT } },
-    { HashStr("ui_itemresult/main/iresult_title/title_bg/center/h_light"), { ALIGN_TOP | EXTEND_LEFT} },
+    { HashStr("ui_itemresult/main/iresult_title/title_bg/center/h_light"), { ALIGN_TOP | EXTEND_LEFT } },
     { HashStr("ui_itemresult/main/iresult_title/title_bg/right"), { ALIGN_TOP | STORE_RIGHT_CORNER } },
 
     // ui_loading
     { HashStr("ui_loading/bg_1"), { STRETCH } },
     { HashStr("ui_loading/bg_2"), { STRETCH } },
+    { HashStr("ui_loading/n_2_d/bg/sky"), { STRETCH } },
+    { HashStr("ui_loading/n_2_d/bg/under"), { STRETCH } },
+    { HashStr("ui_loading/n_2_d/letterbox/letterbox_under"), { STRETCH } },
+    { HashStr("ui_loading/n_2_d/letterbox/letterbox_top"), { STRETCH } },
+    { HashStr("ui_loading/n_2_d/letterbox/black_l"), { EXTEND_LEFT | STRETCH_VERTICAL } },
+    { HashStr("ui_loading/n_2_d/letterbox/black_r"), { EXTEND_RIGHT | STRETCH_VERTICAL } },
 
     // ui_mediaroom
     { HashStr("ui_mediaroom/header/bg/img_1"), { EXTEND_LEFT } },

--- a/UnleashedRecomp/patches/resident_patches.cpp
+++ b/UnleashedRecomp/patches/resident_patches.cpp
@@ -11,13 +11,17 @@ bool m_isSavedAchievementData = false;
 PPC_FUNC_IMPL(__imp__sub_824DCF38);
 PPC_FUNC(sub_824DCF38)
 {
+    auto pLoading = (SWA::CLoading*)g_memory.Translate(ctx.r3.u32);
+
     App::s_isLoading = true;
 
-    // TODO: use the actual PS3 loading screen ("n_2_d").
     if (Config::TimeOfDayTransition == ETimeOfDayTransition::PlayStation)
     {
         if (ctx.r4.u32 == SWA::eLoadingDisplayType_WerehogMovie)
+        {
             ctx.r4.u32 = SWA::eLoadingDisplayType_ChangeTimeOfDay;
+            pLoading->m_IsNightToDay = App::s_isWerehog;
+        }
     }
 
     if (auto pGameDocument = SWA::CGameDocument::GetInstance())


### PR DESCRIPTION
This PR adds proper scaling for the PlayStation Time of Day Transition option. By design, it does not respect the UI Scale Mode option, but that may need to be done manually for something absurd like 9:16 aspect ratio.

This also fixes a bug where a field in `SWA::CLoading` doesn't ever change from `true`, which determines which outro animation to play. Setting this to `false` when the player is the Werehog allows the medal to flip to the Moon Medal when switching to night time.

---

4:3:
![image](https://github.com/user-attachments/assets/b1afa985-3efc-4ef8-87af-550d837b66a0)

---

21:9:
![image](https://github.com/user-attachments/assets/c07e35a1-be1e-45e1-b4c4-f1a03d3a6ac3)

---

9:16:
![image](https://github.com/user-attachments/assets/5105312b-bcfe-4c3f-88bf-56dc9f14288f)

This aspect ratio may need manual adjustments for the background and letterbox casts, if we want to entertain this gimmick even further.

---

Closes https://github.com/hedge-dev/UnleashedRecomp/issues/196.