### PR TITLE
Remove --install from build-flatpak.yml

### DIFF
--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           echo "commit_message=$(git log -1 --pretty=%s)" >> $GITHUB_ENV
           export CCACHE_DIR=/tmp/ccache
-          flatpak-builder --user --force-clean --install-deps-from=flathub --repo=repo --install --ccache builddir ./flatpak/${{ env.FLATPAK_ID }}.json
+          flatpak-builder --user --force-clean --install-deps-from=flathub --repo=repo --ccache builddir ./flatpak/${{ env.FLATPAK_ID }}.json
           flatpak build-bundle repo ./${{ env.FLATPAK_ID }}.flatpak ${{ env.FLATPAK_ID }} --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
 
 # Uploads the built flatpak bundle to GitHub


### PR DESCRIPTION
As what Flatpak-builder's documentation describes, this argument is to install the flatpak directly onto the system. This behaviour is unnecessary for CI builds as we are building and uploading the bundle right after without running the flatpak.

[Flatpak Documentation: Installing builds directly](https://docs.flatpak.org/en/latest/flatpak-builder.html#installing-builds-directly)