### PR TITLE
Added export to disable rounded corners on Windows 11

### DIFF
--- a/UnleashedRecomp/ui/game_window.cpp
+++ b/UnleashedRecomp/ui/game_window.cpp
@@ -231,6 +231,12 @@ void GameWindow::Init(const char* sdlVideoDriver)
 
 #if defined(_WIN32)
     s_renderWindow = info.info.win.window;
+
+    if (Config::DisableDWMRoundedCorners)
+    {
+        DWM_WINDOW_CORNER_PREFERENCE wcp = DWMWCP_DONOTROUND;
+        DwmSetWindowAttribute(s_renderWindow, DWMWA_WINDOW_CORNER_PREFERENCE, &wcp, sizeof(wcp));
+    }
 #elif defined(SDL_VULKAN_ENABLED)
     s_renderWindow = s_pWindow;
 #elif defined(__linux__)

--- a/UnleashedRecomp/user/config_def.h
+++ b/UnleashedRecomp/user/config_def.h
@@ -77,6 +77,7 @@ CONFIG_DEFINE_ENUM_LOCALISED("Video", EUIScaleMode, UIScaleMode, EUIScaleMode::E
 CONFIG_DEFINE_HIDDEN("Exports", bool, AllowCancellingUnleash, false);
 CONFIG_DEFINE_HIDDEN("Exports", bool, DisableAutoSaveWarning, false);
 CONFIG_DEFINE_HIDDEN("Exports", bool, DisableDLCIcon, false);
+CONFIG_DEFINE_HIDDEN("Exports", bool, DisableDWMRoundedCorners, false);
 CONFIG_DEFINE_HIDDEN("Exports", bool, FixUnleashOutOfControlDrain, false);
 CONFIG_DEFINE_HIDDEN("Exports", bool, HomingAttackOnBoost, true);
 CONFIG_DEFINE_HIDDEN("Exports", bool, SaveScoreAtCheckpoints, false);


### PR DESCRIPTION
Xenia uses the same implementation and doesn't check the OS version either, but it'd be worth testing on Windows 10 anyway, just in case.