### PR TITLE
Recompute camera projection matrix during resize to fix stretching on pause menu.

### DIFF
--- a/UnleashedRecomp/patches/camera_patches.cpp
+++ b/UnleashedRecomp/patches/camera_patches.cpp
@@ -48,3 +48,20 @@ PPC_FUNC(sub_824697B0)
 
     __imp__sub_824697B0(ctx, base);
 }
+
+// SWA::CCamera::UpdateSerial
+PPC_FUNC_IMPL(__imp__sub_82467890);
+PPC_FUNC(sub_82467890)
+{
+    if (g_needsResize)
+    {
+        // Recompute the projection matrix for one frame to fix stretching on pause menu.
+        auto r3 = ctx.r3;
+        auto r4 = ctx.r4;
+        sub_82468E38(ctx, base);
+        ctx.r3 = r3;
+        ctx.r4 = r4;
+    }
+
+    __imp__sub_82467890(ctx, base);
+}


### PR DESCRIPTION
Closes #178.