### PR TITLE
Keep world map icons broken at Original 4:3.

### DIFF
--- a/UnleashedRecomp/patches/aspect_ratio_patches.cpp
+++ b/UnleashedRecomp/patches/aspect_ratio_patches.cpp
@@ -1170,8 +1170,12 @@ PPC_FUNC(sub_826906A8)
 
 void WorldMapProjectionMidAsmHook(PPCVRegister& v63, PPCVRegister& v62)
 {
-    v63.f32[3] *= std::max(NARROW_ASPECT_RATIO, g_aspectRatio) / WIDE_ASPECT_RATIO;
-    v62.f32[2] *= NARROW_ASPECT_RATIO / std::min(NARROW_ASPECT_RATIO, g_aspectRatio);
+    // The world map icons are actually broken at 4:3 in the original game!!!
+    if (Config::AspectRatio != EAspectRatio::OriginalNarrow)
+    {
+        v63.f32[3] *= std::max(NARROW_ASPECT_RATIO, g_aspectRatio) / WIDE_ASPECT_RATIO;
+        v62.f32[2] *= NARROW_ASPECT_RATIO / std::min(NARROW_ASPECT_RATIO, g_aspectRatio);
+    }
 }
 
 // CViewRing has the same exact incorrect math as CObjGetItem.


### PR DESCRIPTION
Closes #216.