### PR TITLE
Disable horizontal stretching at narrow aspect ratios.

### DIFF
--- a/UnleashedRecomp/patches/aspect_ratio_patches.cpp
+++ b/UnleashedRecomp/patches/aspect_ratio_patches.cpp
@@ -834,7 +834,7 @@ static void Draw(PPCContext& ctx, uint8_t* base, PPCFunc* original, uint32_t str
     float scaleX = 1.0f;
     float scaleY = 1.0f;
 
-    if ((modifier.flags & STRETCH_HORIZONTAL) != 0)
+    if ((modifier.flags & STRETCH_HORIZONTAL) != 0 && g_aspectRatio >= WIDE_ASPECT_RATIO)
     {
         scaleX = Video::s_viewportWidth / 1280.0f;
     }


### PR DESCRIPTION
Closes #226.