### PR TITLE
Disable ingame frame limiters.

### DIFF
--- a/UnleashedRecomp/patches/fps_patches.cpp
+++ b/UnleashedRecomp/patches/fps_patches.cpp
@@ -120,3 +120,11 @@ PPC_FUNC(sub_8312DBF8)
     while (std::chrono::steady_clock::now() < next)
         std::this_thread::yield();
 }
+
+void WaitVsyncMidAsmHook()
+{
+}
+
+void ApplicationFrameLimiterMidAsmHook()
+{
+}

--- a/UnleashedRecompLib/config/SWA.toml
+++ b/UnleashedRecompLib/config/SWA.toml
@@ -904,3 +904,13 @@ name = "MakeCueSheetDataMidAsmHook"
 address = 0x82E5EA40
 registers = ["r31"]
 jump_address_on_true = 0x82E5EA4C
+
+[[midasm_hook]]
+name = "WaitVsyncMidAsmHook"
+address = 0x82AE2770
+jump_address = 0x82AE2774
+
+[[midasm_hook]]
+name = "ApplicationFrameLimiterMidAsmHook"
+address = 0x822C1064
+jump_address = 0x822C111C


### PR DESCRIPTION
Disables the SFD frame limiter, as well as the 30 FPS one that is behind an if check. Don't know what that one is for, but I'm not risking anything.