### PR TITLE
CTitleStateIntro_patches: fixed message inconsistencies

### DIFF
--- a/UnleashedRecomp/user/registry.cpp
+++ b/UnleashedRecomp/user/registry.cpp
@@ -1,12 +1,6 @@
 #include "registry.h"
 #include <os/process.h>
 #include <os/registry.h>
-#include <user/config.h>
-
-void Registry::Load()
-{
-
-}
 
 void Registry::Save()
 {

--- a/UnleashedRecomp/user/registry.h
+++ b/UnleashedRecomp/user/registry.h
@@ -3,6 +3,5 @@
 class Registry
 {
 public:
-    static void Load();
     static void Save();
 };

--- a/UnleashedRecompLib/config/SWA.toml
+++ b/UnleashedRecompLib/config/SWA.toml
@@ -914,3 +914,7 @@ jump_address = 0x82AE2774
 name = "ApplicationFrameLimiterMidAsmHook"
 address = 0x822C1064
 jump_address = 0x822C111C
+
+[[midasm_hook]]
+name = "PressStartSaveLoadThreadMidAsmHook"
+address = 0x822C4358


### PR DESCRIPTION
This fixes the update and corrupt achievements messages potentially overlapping and also having the demo movie play behind them whilst being displayed.

They're now set up on the same thread as the corrupt save message so they can be properly sequenced by waiting on the thread until the user has dismissed the message.