### PR TITLE
Use a separate upload buffer allocator for the main thread.

### DIFF
--- a/UnleashedRecomp/patches/fps_patches.cpp
+++ b/UnleashedRecomp/patches/fps_patches.cpp
@@ -115,10 +115,7 @@ PPC_FUNC(sub_8312DBF8)
     constexpr auto INTERVAL = 1000000000ns / 60;
     auto next = now + (INTERVAL - now.time_since_epoch() % INTERVAL);
 
-    std::this_thread::sleep_for(std::chrono::floor<std::chrono::milliseconds>(next - now - 1ms));
-
-    while (std::chrono::steady_clock::now() < next)
-        std::this_thread::yield();
+    std::this_thread::sleep_until(next);
 }
 
 void WaitVsyncMidAsmHook()


### PR DESCRIPTION
The PR makes the upload allocator only run in the render thread, which saves on mutex locks in the main thread for every draw call. It turns out the modified range can also be extracted from the dirty flags for vertex/shader constants, which saves about 4-8 KB of data from being copied every draw call if the constants were modified.