### PR TITLE
Check for closing during AchievementOverlay::Open.

### DIFF
--- a/UnleashedRecomp/ui/achievement_overlay.cpp
+++ b/UnleashedRecomp/ui/achievement_overlay.cpp
@@ -167,7 +167,7 @@ void AchievementOverlay::Draw()
 
 void AchievementOverlay::Open(int id)
 {
-    if (s_isVisible)
+    if (s_isVisible && !g_isClosing)
     {
         s_queue.emplace(id);
         return;


### PR DESCRIPTION
Should fix https://github.com/hedge-dev/UnleashedRecomp/issues/291, confirmation pending.