### PR TITLE
Implemented codes list reading for mod loader

### DIFF
--- a/UnleashedRecomp/patches/frontend_listener.cpp
+++ b/UnleashedRecomp/patches/frontend_listener.cpp
@@ -11,7 +11,7 @@ static class FrontendListener : public SDLEventListener
 public:
     bool OnSDLEvent(SDL_Event* event) override
     {
-        if (!Config::HUDToggleHotkey || OptionsMenu::s_isVisible)
+        if (!Config::HUDToggleKey || OptionsMenu::s_isVisible)
             return false;
 
         switch (event->type)

--- a/UnleashedRecomp/patches/player_patches.cpp
+++ b/UnleashedRecomp/patches/player_patches.cpp
@@ -97,7 +97,7 @@ void PostUnleashMidAsmHook(PPCRegister& r30)
 
 void SetXButtonHomingMidAsmHook(PPCRegister& r30)
 {
-    r30.u32 = Config::HomingAttackOnBoost;
+    r30.u32 = !Config::HomingAttackOnJump;
 }
 
 // SWA::Player::CEvilSonicContext

--- a/UnleashedRecomp/user/config_def.h
+++ b/UnleashedRecomp/user/config_def.h
@@ -98,15 +98,15 @@ CONFIG_DEFINE_LOCALISED("Video", bool, XboxColorCorrection, false);
 CONFIG_DEFINE_ENUM_LOCALISED("Video", ECutsceneAspectRatio, CutsceneAspectRatio, ECutsceneAspectRatio::Original);
 CONFIG_DEFINE_ENUM_LOCALISED("Video", EUIAlignmentMode, UIAlignmentMode, EUIAlignmentMode::Edge);
 
-CONFIG_DEFINE_HIDDEN("Exports", bool, AllowCancellingUnleash, false);
-CONFIG_DEFINE_HIDDEN("Exports", bool, DisableAutoSaveWarning, false);
-CONFIG_DEFINE_HIDDEN("Exports", bool, DisableDLCIcon, false);
-CONFIG_DEFINE_HIDDEN("Exports", bool, DisableDWMRoundedCorners, false);
-CONFIG_DEFINE_HIDDEN("Exports", bool, FixUnleashOutOfControlDrain, false);
-CONFIG_DEFINE_HIDDEN("Exports", bool, HomingAttackOnBoost, true);
-CONFIG_DEFINE_HIDDEN("Exports", bool, HUDToggleHotkey, false);
-CONFIG_DEFINE_HIDDEN("Exports", bool, SaveScoreAtCheckpoints, false);
-CONFIG_DEFINE_HIDDEN("Exports", bool, SkipIntroLogos, false);
-CONFIG_DEFINE_HIDDEN("Exports", bool, UseOfficialTitleOnTitleBar, false);
+CONFIG_DEFINE_HIDDEN("Codes", bool, AllowCancellingUnleash, false);
+CONFIG_DEFINE_HIDDEN("Codes", bool, DisableAutoSaveWarning, false);
+CONFIG_DEFINE_HIDDEN("Codes", bool, DisableDLCIcon, false);
+CONFIG_DEFINE_HIDDEN("Codes", bool, DisableDWMRoundedCorners, false);
+CONFIG_DEFINE_HIDDEN("Codes", bool, FixUnleashOutOfControlDrain, false);
+CONFIG_DEFINE_HIDDEN("Codes", bool, HomingAttackOnJump, false);
+CONFIG_DEFINE_HIDDEN("Codes", bool, HUDToggleKey, false);
+CONFIG_DEFINE_HIDDEN("Codes", bool, SaveScoreAtCheckpoints, false);
+CONFIG_DEFINE_HIDDEN("Codes", bool, SkipIntroLogos, false);
+CONFIG_DEFINE_HIDDEN("Codes", bool, UseOfficialTitleOnTitleBar, false);
 
 CONFIG_DEFINE("Update", time_t, LastChecked, 0);


### PR DESCRIPTION
Reads codes by ID from `ModsDB.ini` and enables their respective bools in the config under the `Codes` section.

---

Current code file supported by internal builds of HMM 7/8:
```cs
Patch "Allow Cancelling Unleash" id "AllowCancellingUnleash" in "Gameplay" by "Hyper" does "Allows the player to cancel the Werehog's Unleash ability at the cost of some Dark Gaia energy."

Patch "Boot Directly to Title" id "SkipIntroLogos" in "System" by "Skyth"

Patch "Disable Auto Save Warning" id "DisableAutoSaveWarning" in "UI" by "Hyper" does "Disables the auto save warning that appears after pressing start at the title screen."

Patch "Disable DLC Icon" id "DisableDLCIcon" in "UI" by "Hyper" does "Disables the DLC icon that appears above the flags on the world map if they have DLC content installed."

Patch "Disable Windows 11 Rounded Corners" id "DisableDWMRoundedCorners" in "System" by "Hyper" does "Disables the rounded corners on the game window for Windows 11."

Patch "Fix Unleash Out Of Control Drain" id "FixUnleashOutOfControlDrain" in "Fixes" by "Hyper" does "Fixes the Werehog's Unleash gauge draining whilst an event is playing in a stage that takes away the player's control."

Patch "Homing Attack on Jump" id "HomingAttackOnJump" in "Gameplay" by "Hyper" does "Remaps the homing attack to the A button."

Patch "Save Score at Checkpoints" id "SaveScoreAtCheckpoints" in "Gameplay" by "Hyper" does "Saves your current score upon hitting a checkpoint and restores it when returning to that checkpoint after dying."

Patch "Toggle UI/HUD on F8" id "HUDToggleKey" in "UI" by "RadiantDerg" does "Toggles visibility of the UI and HUD by pressing the F8 key."

Patch "Use Official Title on Title Bar" id "UseOfficialTitleOnTitleBar" in "System" by "Hyper" does "Displays ''SONIC UNLEASHED'' or ''SONIC WORLD ADVENTURE'' on the title bar depending on the selected language."
```