### PR TITLE
Prevent calling GameWindow::Update() outside the main thread.

### DIFF
--- a/UnleashedRecomp/app.cpp
+++ b/UnleashedRecomp/app.cpp
@@ -69,9 +69,9 @@ PPC_FUNC(sub_822C1130)
     {
         SDL_PumpEvents();
         SDL_FlushEvents(SDL_FIRSTEVENT, SDL_LASTEVENT);
+        GameWindow::Update();
     }
 
-    GameWindow::Update();
     AudioPatches::Update(App::s_deltaTime);
     InspirePatches::Update();
 


### PR DESCRIPTION
The game seems to freeze if the user tries to resize during loading, as the SDL events don't get flushed and it just gets stuck waiting when trying to set the title. This seems to fix it...?