### PR TITLE
Disable primitive 2D pixel snapping & enforce linear only above 720p.

### DIFF
--- a/UnleashedRecomp/patches/aspect_ratio_patches.cpp
+++ b/UnleashedRecomp/patches/aspect_ratio_patches.cpp
@@ -1198,12 +1198,6 @@ PPC_FUNC(sub_830D1EF0)
             y = g_aspectRatioOffsetY + (y + 0.5f) * g_aspectRatioScale;
         }
 
-        if (Config::AspectRatio != EAspectRatio::OriginalNarrow)
-        {
-            x = round(x);
-            y = round(y);
-        }
-
         vertex[i].x = ((x - 0.5f) / Video::s_viewportWidth) * 2.0f - 1.0f;
         vertex[i].y = ((y - 0.5f) / Video::s_viewportHeight) * -2.0f + 1.0f;
     }

--- a/UnleashedRecomp/patches/video_patches.cpp
+++ b/UnleashedRecomp/patches/video_patches.cpp
@@ -76,8 +76,12 @@ PPC_FUNC(sub_830D25D8)
     auto device = reinterpret_cast<GuestDevice*>(base + PPC_LOAD_U32(ctx.r4.u32));
 
     // Set first sampler to use linear filtering.
-    device->samplerStates[0].data[3] = (device->samplerStates[0].data[3].get() & ~0x1f80000) | 0x1280000;
-    device->dirtyFlags[3] = device->dirtyFlags[3].get() | 0x80000000ull;
+    // NOTE: We only check for height here since all 2D primitives get centered.
+    if (Video::s_viewportHeight > 720)
+    {
+        device->samplerStates[0].data[3] = (device->samplerStates[0].data[3].get() & ~0x1f80000) | 0x1280000;
+        device->dirtyFlags[3] = device->dirtyFlags[3].get() | 0x80000000ull;
+    }
 
     __imp__sub_830D25D8(ctx, base);
 }


### PR DESCRIPTION
Closes #329.