### PR TITLE
Implemented FPS overlay

### DIFF
--- a/UnleashedRecomp/gpu/video.cpp
+++ b/UnleashedRecomp/gpu/video.cpp
@@ -2258,6 +2258,9 @@ static void DrawProfiler()
             ImGui::Text("SDL Video Driver: %s", sdlVideoDriver);
 
         ImGui::NewLine();
+        ImGui::Checkbox("Show FPS", &Config::ShowFPS.Value);
+        ImGui::NewLine();
+
         if (ImGui::TreeNode("Device Names"))
         {
             ImGui::Indent();
@@ -2276,6 +2279,36 @@ static void DrawProfiler()
 
     ImGui::PopFont();
     font->Scale = defaultScale;
+}
+
+static void DrawFPS()
+{
+    if (!Config::ShowFPS)
+        return;
+
+    double time = ImGui::GetTime();
+    static double updateTime = time;
+    static double fps = 0;
+
+    if (time - updateTime >= 1.0f)
+    {
+        fps = 1000.0 / g_presentProfiler.value.load();
+        updateTime = time;
+    }
+
+    auto drawList = ImGui::GetBackgroundDrawList();
+
+    auto fmt = fmt::format("FPS: {:.2f}", fps);
+    auto font = ImFontAtlasSnapshot::GetFont("FOT-SeuratPro-M.otf");
+    auto fontSize = Scale(10);
+    auto textSize = font->CalcTextSizeA(fontSize, FLT_MAX, 0, fmt.c_str());
+
+    ImVec2 min = { Scale(40), Scale(30) };
+    ImVec2 max = { min.x + std::max(Scale(75), textSize.x + Scale(10)), min.y + Scale(15) };
+    ImVec2 textPos = { min.x + Scale(2), CENTRE_TEXT_VERT(min, max, textSize) + Scale(0.2f) };
+
+    drawList->AddRectFilled(min, max, IM_COL32(0, 0, 0, 200));
+    drawList->AddText(font, fontSize, textPos, IM_COL32_WHITE, fmt.c_str());
 }
 
 static void DrawImGui()
@@ -2338,6 +2371,7 @@ static void DrawImGui()
 
     assert(ImGui::GetBackgroundDrawList()->_ClipRectStack.Size == 1 && "Some clip rects were not removed from the stack!");
 
+    DrawFPS();
     DrawProfiler();
     ImGui::Render();
 

--- a/UnleashedRecomp/user/config_def.h
+++ b/UnleashedRecomp/user/config_def.h
@@ -87,6 +87,7 @@ CONFIG_DEFINE_CALLBACK("Video", bool, Fullscreen, true,
 CONFIG_DEFINE_LOCALISED("Video", bool, VSync, true);
 CONFIG_DEFINE_ENUM("Video", ETripleBuffering, TripleBuffering, ETripleBuffering::Auto);
 CONFIG_DEFINE_LOCALISED("Video", int32_t, FPS, 60);
+CONFIG_DEFINE("Video", bool, ShowFPS, false);
 CONFIG_DEFINE("Video", uint32_t, MaxFrameLatency, 2);
 CONFIG_DEFINE_LOCALISED("Video", float, Brightness, 0.5f);
 CONFIG_DEFINE_ENUM_LOCALISED("Video", EAntiAliasing, AntiAliasing, EAntiAliasing::MSAA4x);


### PR DESCRIPTION
Ported over the FPS overlay from the debug-menu branch, as I personally find it useful to see this info internally without external programs or the big profiler window getting in the way.

You can toggle it in the config with `ShowFPS = true` or using a checkbox in the profiler window.

---

![image](https://github.com/user-attachments/assets/9f1b30da-5a25-43c9-bd74-79d622963c60)

---

It replicates the design used in the preview builds of Unleashed, just without the Arial font.