### PR TITLE
Fix Rooftop Run barrels rolling backwards at HFR

### DIFF
--- a/UnleashedRecomp/patches/fps_patches.cpp
+++ b/UnleashedRecomp/patches/fps_patches.cpp
@@ -28,6 +28,17 @@ void HighFrameRateDeltaTimeFixMidAsmHook(PPCRegister& f1)
         f1.f64 = threshold;
 }
 
+// This hook expects the vector register to store delta time at the first index.
+void HighFrameRateDeltaTimeFixVectorMidAsmHook(PPCVRegister& v62)
+{
+    // Having 60 FPS threshold ensures we still retain
+    // the original game behavior when locked to 30/60 FPS.
+    constexpr double threshold = 1.0 / 60.0;
+
+    if (v62.f32[3] < threshold)
+        v62.f32[3] = threshold;
+}
+
 void CameraDeltaTimeFixMidAsmHook(PPCRegister& dest, PPCRegister& src)
 {
     dest.f64 = src.f64 / 30.0;

--- a/UnleashedRecompLib/config/SWA.toml
+++ b/UnleashedRecompLib/config/SWA.toml
@@ -973,3 +973,9 @@ registers = ["r30", "f30"]
 name = "SparkleLocusMidAsmHook"
 address = 0x82E96804
 jump_address_on_true = 0x82E96808
+
+# Rooftop Run barrel fix (works at up to ~400 FPS)
+[[midasm_hook]]
+name = "HighFrameRateDeltaTimeFixVectorMidAsmHook"
+address = 0x827673CC
+registers = ["v62"]


### PR DESCRIPTION
This fix works at up to ~400 FPS before the barrels begin floating off the ground, so it's not perfect but it'll work for most cases.

Closes https://github.com/hedge-dev/UnleashedRecomp/issues/307.