### PR TITLE
Fix options menu info scroll marquee fade

### DIFF
--- a/UnleashedRecomp/ui/options_menu.cpp
+++ b/UnleashedRecomp/ui/options_menu.cpp
@@ -1583,7 +1583,7 @@ static void DrawInfoPanel(ImVec2 infoMin, ImVec2 infoMax)
             scrollDirection = 1.0f;
         }
 
-        SetVerticalMarqueeFade(clipRectMin, clipRectMax, Scale(24), Lerp(Scale(24), 0.0f, scrollOffset / scrollMax));
+        SetVerticalMarqueeFade({ clipRectMin.x, clipRectMin.y + Scale(5.5f) }, clipRectMax, Scale(10), Scale(10));
 
         DrawRubyAnnotatedText
         (


### PR DESCRIPTION
I was lerping the fade amount by how far the text has scrolled, so if you had a really long description, there'd basically be no fade at all.

The text was also scrolling up and clipping with the thumbnail instead of fading below it, which bothered me.