### PR TITLE
Fix rail booster sounds overlapping at HFR

### DIFF
--- a/UnleashedRecompLib/config/SWA.toml
+++ b/UnleashedRecompLib/config/SWA.toml
@@ -1086,3 +1086,8 @@ registers = ["r4"]
 name = "AnimationDataMakeMidAsmHook"
 address = 0x82BB38E4
 registers = ["r31", "r29", "r28"]
+
+[[midasm_hook]]
+name = "ObjGrindDashPanelAllocMidAsmHook"
+address = 0x82614948
+registers = ["r3"]


### PR DESCRIPTION
Partially addresses https://github.com/hedge-dev/UnleashedRecomp/issues/255.

The rail boosters are the most egregious when it comes to this issue, so might as well prioritise this one.