### PR TITLE
Implement workaround for Mesa triangle strip bug.

### DIFF
--- a/UnleashedRecomp/gpu/video.cpp
+++ b/UnleashedRecomp/gpu/video.cpp
@@ -285,9 +285,7 @@ static bool g_vulkan = false;
 static constexpr bool g_vulkan = true;
 #endif
 
-#ifndef _WIN32
 static bool g_mesaTriangleStripWorkaround = false;
-#endif
 
 static constexpr bool g_hardwareResolve = true;
 static constexpr bool g_hardwareDepthResolve = true;
@@ -1704,14 +1702,13 @@ bool Video::CreateHostDevice(const char *sdlVideoDriver)
                 g_vulkan = (interfaceFunction == CreateVulkanInterfaceWrapper);
 #endif
 
-#ifndef _WIN32
                 if (interfaceFunction == CreateVulkanInterfaceWrapper)
                 {
                     // Enable triangle strip workaround if we are on the Mesa RADV driver, as it currently has a bug where
                     // restart indices cause triangles to be culled incorrectly. Converting them to degenerate triangles fixes it.
                     g_mesaTriangleStripWorkaround = deviceDescription.name.find(" (RADV ") != std::string::npos;
                 }
-#endif
+
                 break;
             }
         }
@@ -2331,9 +2328,7 @@ static void DrawProfiler()
         ImGui::Text("Present Wait: %s", g_capabilities.presentWait ? "Supported" : "Unsupported");
         ImGui::Text("Triangle Fan: %s", g_capabilities.triangleFan ? "Supported" : "Unsupported");
         ImGui::Text("Dynamic Depth Bias: %s", g_capabilities.dynamicDepthBias ? "Supported" : "Unsupported");
-#ifndef _WIN32
         ImGui::Text("Triangle Strip Workaround: %s", g_mesaTriangleStripWorkaround ? "Enabled" : "Disabled");
-#endif
         ImGui::NewLine();
 
         ImGui::Text("API: %s", g_vulkan ? "Vulkan" : "D3D12");
@@ -7418,8 +7413,6 @@ bool FxShadowMapMidAsmHook(PPCRegister& r4, PPCRegister& r5, PPCRegister& r6, PP
     }
 }
 
-#ifndef _WIN32
-
 // There is a driver bug on Mesa where restart indices cause incorrect culling and prevent some triangles from being rendered.
 // Restart indices can be converted to degenerate triangles as a workaround until this issue gets fixed.
 static void ConvertToDegenerateTriangles(uint16_t* indices, uint32_t indexCount, uint16_t*& newIndices, uint32_t& newIndexCount)
@@ -7600,8 +7593,6 @@ PPC_FUNC(sub_82E3B1C0)
     if (newIndices != nullptr)
         g_userHeap.Free(newIndices);
 }
-
-#endif
 
 GUEST_FUNCTION_HOOK(sub_82BD99B0, CreateDevice);
 


### PR DESCRIPTION
Fixes #294. The real culprit seems to be the usage of restart indices, it either causes the backface culling of certain triangles to be flipped, or the triangles just don't get rendered. Converting restart indices to degenerate triangles seems to work.