### PR TITLE
Append inaccessible reasons to options menu descriptions

### DIFF
--- a/UnleashedRecomp/ui/options_menu.cpp
+++ b/UnleashedRecomp/ui/options_menu.cpp
@@ -1458,7 +1458,7 @@ static void DrawInfoPanel(ImVec2 infoMin, ImVec2 infoMax)
 
         if (g_inaccessibleReason)
         {
-            desc = *g_inaccessibleReason;
+            desc += "\n\n" + *g_inaccessibleReason;
         }
         else
         {
@@ -1476,10 +1476,9 @@ static void DrawInfoPanel(ImVec2 infoMin, ImVec2 infoMax)
             }
 
             const auto& valueDescription = g_selectedItem->GetValueDescription(Config::Language);
+
             if (!valueDescription.empty())
-            {
                 desc += "\n\n" + valueDescription;
-            }
         }
 
         clipRectMin = { clipRectMin.x, thumbnailMax.y };


### PR DESCRIPTION
As opposed to completely replacing the original description, makes things less vague if they're inaccessible to new users.

Closes https://github.com/hedge-dev/UnleashedRecomp/issues/445.