### PR TITLE
Updated flatpak build script

### DIFF
--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -14,29 +14,32 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - name: Checkout repository
+      - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
           token: ${{ secrets.ORG_TOKEN }}
 
-      - name: Checkout private repository
+      - name: Checkout Private Repository
         uses: actions/checkout@v4
         with:
           repository: ${{ secrets.ASSET_REPO }}
           token: ${{ secrets.ASSET_REPO_TOKEN }}
-          path: flatpak/private
+          path: ./private
 
-      - name: Install dependencies
+      - name: Install Dependencies
         run: |-
           sudo apt update
           sudo apt install -y flatpak-builder ccache
 
-      - name: Cache ccache directory
+      - name: Setup ccache
         uses: actions/cache@v4
         with:
           path: /tmp/ccache
           key: ccache-${{ runner.os }}
+
+      - name: Prepare Project
+        run: cp ./private/* ./UnleashedRecompLib/private  
 
       - name: Prepare Flatpak
         run: |

--- a/flatpak/io.github.hedge_dev.unleashedrecomp.json
+++ b/flatpak/io.github.hedge_dev.unleashedrecomp.json
@@ -32,31 +32,6 @@
         {
           "type": "dir",
           "path": "../"
-        },
-        {
-          "type": "file",
-          "path": "private/default.xex",
-          "dest": "UnleashedRecompLib/private"
-        },
-        {
-          "type": "file",
-          "path": "private/default.xexp",
-          "dest": "UnleashedRecompLib/private"
-        },
-        {
-          "type": "file",
-          "path": "private/default_patched.xex",
-          "dest": "UnleashedRecompLib/private"
-        },
-        {
-          "type": "file",
-          "path": "private/shader.ar",
-          "dest": "UnleashedRecompLib/private"
-        },
-        {
-          "type": "file",
-          "path": "private/shader_decompressed.ar",
-          "dest": "UnleashedRecompLib/private"
         }
       ],
       "build-options": {


### PR DESCRIPTION
I have updated the flatpak build script to nolonger require a private directory in the flatpak directory. This is done because the project itself has its own way of storing the files and the flatpak script here is meant to act as just a build script.

The changed CI script has also been tested. 