### PR TITLE
Fixing typo in French translation.

### DIFF
--- a/UnleashedRecomp/locale/locale.cpp
+++ b/UnleashedRecomp/locale/locale.cpp
@@ -378,7 +378,7 @@ std::unordered_map<std::string_view, std::unordered_map<ELanguage, std::string>>
             { ELanguage::English,  "Installation failed.\n\nError: " },
             { ELanguage::Japanese, "インストールに[失敗:しっぱい]しました\n\nエラー： " },
             { ELanguage::German,   "Installation fehlgeschlagen.\n\nFehler: " },
-            { ELanguage::French,   "L'installation a échouée.\n\nErreur : " },
+            { ELanguage::French,   "L'installation a échoué.\n\nErreur : " },
             { ELanguage::Spanish,  "La instalación falló.\n\nError: " },
             { ELanguage::Italian,  "Installazione fallita.\n\nErrore: " }
         }


### PR DESCRIPTION
Just fixing a very small typo, you'd rather say "a échoué" than "a échouée".