### PR TITLE
Changed the game name "Sonic World Adventure" to "Sonic Unleashed" in Japanese installer introduction text

### DIFF
--- a/UnleashedRecomp/locale/locale.cpp
+++ b/UnleashedRecomp/locale/locale.cpp
@@ -304,7 +304,7 @@ std::unordered_map<std::string_view, std::unordered_map<ELanguage, std::string>>
         "Installer_Page_Introduction",
         {
             { ELanguage::English,  "Welcome to\nUnleashed Recompiled!\n\nYou'll need an Xbox 360 copy\nof Sonic Unleashed in order to proceed with the installation." },
-            { ELanguage::Japanese, "Unleashed Recompiledへようこそ！\nインストールにはXbox 360[版:ばん]の\n「ソニック ワールドアドベンチャー」\nが必要です" },
+            { ELanguage::Japanese, "Unleashed Recompiledへようこそ！\nインストールには[北米版:ほくべいばん]またはEU[版:ばん]のXbox 360[用:よう]の\n「Sonic Unleashed」\nが[必要:ひつよう]です" },
             { ELanguage::German,   "Willkommen zu\nUnleashed Recompiled!\nEs wird eine Xbox 360 Kopie von Sonic Unleashed benötigt um mit der Installation fortfahren zu können." },
             { ELanguage::French,   "Bienvenue sur\nUnleashed Recompiled !\n\nVous aurez besoin d'une copie de Sonic Unleashed pour Xbox\n360 pour procéder à l'installation." },
             { ELanguage::Spanish,  "¡Bienvenido a\nUnleashed Recompiled!\n\nNecesitas una copia de\nSonic Unleashed de Xbox 360\npara continuar con la instalación." },

--- a/UnleashedRecomp/locale/locale.cpp
+++ b/UnleashedRecomp/locale/locale.cpp
@@ -304,7 +304,7 @@ std::unordered_map<std::string_view, std::unordered_map<ELanguage, std::string>>
         "Installer_Page_Introduction",
         {
             { ELanguage::English,  "Welcome to\nUnleashed Recompiled!\n\nYou'll need an Xbox 360 copy\nof Sonic Unleashed in order to proceed with the installation." },
-            { ELanguage::Japanese, "Unleashed Recompiledへようこそ！\nインストールには[北米版:ほくべいばん]またはEU[版:ばん]のXbox 360[用:よう]の\n「Sonic Unleashed」\nが[必要:ひつよう]です" },
+            { ELanguage::Japanese, "Unleashed Recompiledへようこそ！\nインストールには\nUS[版:ばん]またはEU[版:ばん]のXbox 360[用:よう]\n「Sonic Unleashed」が[必要:ひつよう]です" },
             { ELanguage::German,   "Willkommen zu\nUnleashed Recompiled!\nEs wird eine Xbox 360 Kopie von Sonic Unleashed benötigt um mit der Installation fortfahren zu können." },
             { ELanguage::French,   "Bienvenue sur\nUnleashed Recompiled !\n\nVous aurez besoin d'une copie de Sonic Unleashed pour Xbox\n360 pour procéder à l'installation." },
             { ELanguage::Spanish,  "¡Bienvenido a\nUnleashed Recompiled!\n\nNecesitas una copia de\nSonic Unleashed de Xbox 360\npara continuar con la instalación." },

--- a/UnleashedRecomp/locale/locale.cpp
+++ b/UnleashedRecomp/locale/locale.cpp
@@ -304,7 +304,7 @@ std::unordered_map<std::string_view, std::unordered_map<ELanguage, std::string>>
         "Installer_Page_Introduction",
         {
             { ELanguage::English,  "Welcome to\nUnleashed Recompiled!\n\nYou'll need an Xbox 360 copy\nof Sonic Unleashed in order to proceed with the installation." },
-            { ELanguage::Japanese, "Unleashed Recompiledへようこそ！\nインストールには\nUS[版:ばん]またはEU[版:ばん]のXbox 360[用:よう]\n「Sonic Unleashed」が[必要:ひつよう]です" },
+            { ELanguage::Japanese, "Unleashed Recompiledへようこそ！\nインストールには\n[北米版:ほくべいばん]またはEU[版:ばん]のXbox 360[用:よう]\n「SONIC UNLEASHED」が[必要:ひつよう]です" },
             { ELanguage::German,   "Willkommen zu\nUnleashed Recompiled!\nEs wird eine Xbox 360 Kopie von Sonic Unleashed benötigt um mit der Installation fortfahren zu können." },
             { ELanguage::French,   "Bienvenue sur\nUnleashed Recompiled !\n\nVous aurez besoin d'une copie de Sonic Unleashed pour Xbox\n360 pour procéder à l'installation." },
             { ELanguage::Spanish,  "¡Bienvenido a\nUnleashed Recompiled!\n\nNecesitas una copia de\nSonic Unleashed de Xbox 360\npara continuar con la instalación." },


### PR DESCRIPTION
Referring to "Sonic Unleashed" as "Sonic World Adventure" may cause misunderstandings, making it seem as if the JP version of the game is supported.
Additionally, to emphasize the necessity of the NA and EU versions, they should be explicitly mentioned.