### PR TITLE
Improve .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -397,3 +397,16 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+# IntelliJ IDEs
+.idea/
+
+# macOS metadata
+*.DS_Store
+
+# CMake Files
+**/cmake-build-debug
+**/CMakeCache.txt
+
+# Unleashed game files
+private/

--- a/.gitignore
+++ b/.gitignore
@@ -407,6 +407,3 @@ FodyWeavers.xsd
 # CMake Files
 **/cmake-build-debug
 **/CMakeCache.txt
-
-# Unleashed game files
-private/


### PR DESCRIPTION
Hides IntelliJ IDE files, macOS metadata, and some CMake files.