### PR TITLE
Run workflows on commit and PR

### DIFF
--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -20,7 +20,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.ORG_TOKEN }}
 
       - name: Checkout Private Repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -1,7 +1,8 @@
 name: Build Project (Flatpak)
 
 on:
-  pull_request:
+  pull_request_target:
+    types: [ opened, synchronize ]
   push:
   workflow_dispatch:
 

--- a/.github/workflows/build-flatpak.yml
+++ b/.github/workflows/build-flatpak.yml
@@ -1,6 +1,8 @@
 name: Build Project (Flatpak)
 
 on:
+  pull_request:
+  push:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,6 +1,8 @@
 name: Build Project (Linux)
 
 on:
+  pull_request:
+  push:
   workflow_dispatch:
 
 env:

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,7 +1,8 @@
 name: Build Project (Linux)
 
 on:
-  pull_request:
+  pull_request_target:
+    types: [ opened, synchronize ]
   push:
   workflow_dispatch:
 

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.ORG_TOKEN }}
 
       - name: Checkout Private Repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.ORG_TOKEN }}
 
       - name: Checkout private repository
         uses: actions/checkout@v4

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,7 +1,8 @@
 name: Build Project (Windows)
 
 on:
-  pull_request:
+  pull_request_target:
+    types: [ opened, synchronize ]
   push:
   workflow_dispatch:
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,6 +1,8 @@
 name: Build Project (Windows)
 
 on:
+  pull_request:
+  push:
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
These can then also be marked as required to ensure PRs don't break build.