### PR TITLE
Add hidden DisableDPadAsAnalogInput option

### DIFF
--- a/UnleashedRecomp/patches/input_patches.cpp
+++ b/UnleashedRecomp/patches/input_patches.cpp
@@ -212,6 +212,9 @@ g_sdlEventListenerForInputPatches;
 
 static bool IsDPadThreshold(const SWA::SPadState* pPadState)
 {
+    if (Config::DisableDPadAsAnalogInput)
+        return false;
+
     return pPadState->IsDown(SWA::eKeyState_DpadUp)   ||
            pPadState->IsDown(SWA::eKeyState_DpadDown) ||
            pPadState->IsDown(SWA::eKeyState_DpadLeft) ||
@@ -237,6 +240,9 @@ static bool IsCursorThreshold(double deadzone = 0, bool isBelowThreshold = false
 
 static void SetDPadAnalogDirectionX(PPCRegister& pPadState, PPCRegister& x, bool invert, float max = 1.0f)
 {
+    if (Config::DisableDPadAsAnalogInput)
+        return;
+
     auto pGuestPadState = (SWA::SPadState*)g_memory.Translate(pPadState.u32);
 
     if (pGuestPadState->IsDown(SWA::eKeyState_DpadLeft))
@@ -248,6 +254,9 @@ static void SetDPadAnalogDirectionX(PPCRegister& pPadState, PPCRegister& x, bool
 
 static void SetDPadAnalogDirectionY(PPCRegister& pPadState, PPCRegister& y, bool invert, float max = 1.0f)
 {
+    if (Config::DisableDPadAsAnalogInput)
+        return;
+
     auto pGuestPadState = (SWA::SPadState*)g_memory.Translate(pPadState.u32);
 
     if (pGuestPadState->IsDown(SWA::eKeyState_DpadUp))
@@ -283,6 +292,9 @@ void PostureDPadSupportYMidAsmHook(PPCRegister& pPadState, PPCRegister& y)
 
 void PostureSpaceHurrierDPadSupportXMidAsmHook(PPCRegister& pPadState, PPCVRegister& vector)
 {
+    if (Config::DisableDPadAsAnalogInput)
+        return;
+    
     auto pGuestPadState = (SWA::SPadState*)g_memory.Translate(pPadState.u32);
 
     if (pGuestPadState->IsDown(SWA::eKeyState_DpadLeft))
@@ -294,6 +306,9 @@ void PostureSpaceHurrierDPadSupportXMidAsmHook(PPCRegister& pPadState, PPCVRegis
 
 void PostureSpaceHurrierDPadSupportYMidAsmHook(PPCRegister& pPadState, PPCVRegister& vector)
 {
+    if (Config::DisableDPadAsAnalogInput)
+        return;
+
     auto pGuestPadState = (SWA::SPadState*)g_memory.Translate(pPadState.u32);
 
     if (pGuestPadState->IsDown(SWA::eKeyState_DpadUp))
@@ -403,17 +418,20 @@ PPC_FUNC(sub_8256C938)
         pWorldMapCursor->m_LeftStickVertical = rPadState.LeftStickVertical;
         pWorldMapCursor->m_LeftStickHorizontal = rPadState.LeftStickHorizontal;
 
-        if (rPadState.IsDown(SWA::eKeyState_DpadUp))
-            pWorldMapCursor->m_LeftStickVertical = 1.0f;
-
-        if (rPadState.IsDown(SWA::eKeyState_DpadDown))
-            pWorldMapCursor->m_LeftStickVertical = -1.0f;
-
-        if (rPadState.IsDown(SWA::eKeyState_DpadLeft))
-            pWorldMapCursor->m_LeftStickHorizontal = -1.0f;
-
-        if (rPadState.IsDown(SWA::eKeyState_DpadRight))
-            pWorldMapCursor->m_LeftStickHorizontal = 1.0f;
+        if (!Config::DisableDPadAsAnalogInput)
+        {
+            if (rPadState.IsDown(SWA::eKeyState_DpadUp))
+                pWorldMapCursor->m_LeftStickVertical = 1.0f;
+    
+            if (rPadState.IsDown(SWA::eKeyState_DpadDown))
+                pWorldMapCursor->m_LeftStickVertical = -1.0f;
+    
+            if (rPadState.IsDown(SWA::eKeyState_DpadLeft))
+                pWorldMapCursor->m_LeftStickHorizontal = -1.0f;
+    
+            if (rPadState.IsDown(SWA::eKeyState_DpadRight))
+                pWorldMapCursor->m_LeftStickHorizontal = 1.0f;
+        }
 
         if (sqrtl((pWorldMapCursor->m_LeftStickHorizontal * pWorldMapCursor->m_LeftStickHorizontal) +
             (pWorldMapCursor->m_LeftStickVertical * pWorldMapCursor->m_LeftStickVertical)) > WORLD_MAP_ROTATE_DEADZONE)

--- a/UnleashedRecomp/user/config_def.h
+++ b/UnleashedRecomp/user/config_def.h
@@ -92,5 +92,6 @@ CONFIG_DEFINE_HIDDEN("Codes", bool, SkipIntroLogos, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, UseArrowsForTimeOfDayTransition, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, UseOfficialTitleOnTitleBar, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, DisableLowResolutionFontOnCustomUI, false);
+CONFIG_DEFINE_HIDDEN("Codes", bool, DisableDPadAsAnalogInput, false);
 
 CONFIG_DEFINE("Update", time_t, LastChecked, 0);


### PR DESCRIPTION
This PR adds a configuration entry in the 'Codes' section named DPadAsAnalogInput allowing someone to enable or disable the movement of Sonic / the world map cursor using the directional pad buttons.
This default behavior on the original game was to not move Sonic / the world map cursor when the dpad was used, I thought it would be good to let people choose this if they want. Let me know if anything else needs to be changed.