### PR TITLE
Update README.md as the GT 630 doesn't support Shader Model 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Unleashed Recompiled is an unofficial PC port of the Xbox 360 version of Sonic U
   - Intel: Sandy Bridge (Intel Core 2nd Generation)
   - AMD: Bulldozer (AMD FX series)
 - GPU with support for Direct3D 12.0 (Shader Model 6) or Vulkan 1.2:
-  - NVIDIA: GeForce GT 630
+  - NVIDIA: Kepler GPU (Cards with the same name may have different architectures)
   - AMD: Radeon HD 7750 (2012, not the RX 7000)
   - Intel: HD Graphics 510 (Skylake)
 - Operating System:


### PR DESCRIPTION
The [GT 630](https://www.techpowerup.com/gpu-specs/geforce-gt-630.c816) is Fermi while Shader Model 6 needs a Kepler card (which is used by the [GT 630 OEM](https://www.techpowerup.com/gpu-specs/geforce-gt-630-oem.c818)).

Since Nvidia makes GPUs with the same name but different architectures (See [Kepler GT 1030](https://www.techpowerup.com/gpu-specs/geforce-gt-1030-gk107.c3454)) it will be easier to specify the minimum requirement as needing Kepler architecture.