### PR TITLE
Support for More Languages in Installer Wizard

### DIFF
--- a/UnleashedRecomp/ui/installer_wizard.cpp
+++ b/UnleashedRecomp/ui/installer_wizard.cpp
@@ -1240,13 +1240,21 @@ static void DrawLanguagePicker()
     {
         float alphaMotion = ComputeMotionInstaller(g_appearTime, g_disappearTime, CONTAINER_INNER_TIME, CONTAINER_INNER_DURATION);
         float minX, maxX;
-        bool buttonPressed;
+        bool buttonPressed = false;
 
-        for (int i = 0; i < 6; i++)
+        int numLanguages = sizeof(LANGUAGE_TEXT) / sizeof(LANGUAGE_TEXT[0]);
+
+        int numColumns = 2;
+        int numRows = (numLanguages + numColumns - 1) / numColumns;
+
+        for (int i = 0; i < numLanguages; i++)
         {
-            ComputeButtonColumnCoordinates((i < 3) ? ButtonColumnLeft : ButtonColumnRight, minX, maxX);
+            ButtonColumn column = (i % numColumns == 0) ? ButtonColumnLeft : ButtonColumnRight;
+            ComputeButtonColumnCoordinates(column, minX, maxX);
 
-            float minusY = (CONTAINER_BUTTON_GAP + BUTTON_HEIGHT) * (float(i % 3));
+            float rowIndex = i / numColumns;
+            float minusY = (CONTAINER_BUTTON_GAP + BUTTON_HEIGHT) * rowIndex;
+
             ImVec2 min = { minX, g_aspectRatioOffsetY + Scale(CONTAINER_Y + CONTAINER_HEIGHT - CONTAINER_BUTTON_GAP - BUTTON_HEIGHT - minusY) };
             ImVec2 max = { maxX, g_aspectRatioOffsetY + Scale(CONTAINER_Y + CONTAINER_HEIGHT - CONTAINER_BUTTON_GAP - minusY) };
 


### PR DESCRIPTION
DrawLanguagePicker from installer wizard is using a fixed value _(6)_ to list languages to the selection screen.

If a new Language is added, it wont be shown on the selection screen, and if the value is increased to 7, the new language will overflow the last one on the list due to the 3x2 grid.

![image](https://github.com/user-attachments/assets/83a1ae7e-2f61-495a-9b3e-ad374496d235)


This change the use of a fixed value to a count from the Enum so this problem wont happen if more languages are added by the community.

![image](https://github.com/user-attachments/assets/f6720e75-8c13-4b0c-99b9-6206ef38c71a)
