### PR TITLE
Add custom aspect ratios

### DIFF
--- a/UnleashedRecomp/gpu/video.cpp
+++ b/UnleashedRecomp/gpu/video.cpp
@@ -2913,6 +2913,26 @@ void Video::ComputeViewportDimensions()
 
         break;
     }
+    
+    case EAspectRatio::Custom:
+    {
+        uint32_t horzAspect = Config::AspectWidth;
+        uint32_t vertAspect = Config::AspectHeight;
+        float customAspectRatio = float(horzAspect) / float(vertAspect);
+
+        if (aspectRatio > customAspectRatio)
+        {
+            s_viewportWidth = height * horzAspect / vertAspect;
+            s_viewportHeight = height;
+        }
+        else
+        {
+            s_viewportWidth = width;
+            s_viewportHeight = width * vertAspect / horzAspect;
+        }
+
+        break;
+    }
 
     default:
         s_viewportWidth = width;
@@ -7344,6 +7364,8 @@ void VideoConfigValueChangedCallback(IConfigDef* config)
     // Config options that require internal resolution resize
     g_needsResize |=
         config == &Config::AspectRatio ||
+        config == &Config::AspectWidth ||
+        config == &Config::AspectHeight ||
         config == &Config::ResolutionScale ||
         config == &Config::AntiAliasing ||
         config == &Config::ShadowResolution;

--- a/UnleashedRecomp/locale/config_locale.cpp
+++ b/UnleashedRecomp/locale/config_locale.cpp
@@ -563,9 +563,9 @@ CONFIG_DEFINE_ENUM_LOCALE(EAspectRatio)
         ELanguage::German,
         {
             { EAspectRatio::Auto, { "AUTO", "Auto: Das Seitenverhältnis passt sich automatisch der Fenstergröße an." } },
-            { EAspectRatio::Wide, { "16:9", "16:9: Stellt das Spiel in einem Breitbildschirm-Vormat dar." } },
-            { EAspectRatio::Narrow, { "4:3", "4:3: Stellt das Spiel in einem Mittel-Vormat dar." } },
-            { EAspectRatio::OriginalNarrow, { "ORIGINAL 4:3", "Original 4:3: Stellt das Spiel in einem Mittel-Vormat dar, was der ursprünglichen Implementation originalgetreut bleibt." } }
+            { EAspectRatio::Wide, { "16:9", "16:9: Stellt das Spiel in einem Breitbildschirm-Format dar." } },
+            { EAspectRatio::Narrow, { "4:3", "4:3: Stellt das Spiel in einem Mittel-Format dar." } },
+            { EAspectRatio::OriginalNarrow, { "ORIGINAL 4:3", "Original 4:3: Stellt das Spiel in einem Mittel-Format dar, was der ursprünglichen Implementation originalgetreut bleibt." } },
             { EAspectRatio::Custom, { "Benutzerdefiniert", "Das Seitenverhältnis entspricht den Werten in 'Seitenverhältnis-Breite' und 'Seitenverhältnis-Höhe'." } }
         }
     },

--- a/UnleashedRecomp/locale/config_locale.cpp
+++ b/UnleashedRecomp/locale/config_locale.cpp
@@ -546,7 +546,8 @@ CONFIG_DEFINE_ENUM_LOCALE(EAspectRatio)
             { EAspectRatio::Auto, { "AUTO", "Auto: the aspect ratio will dynamically adjust to the window size." } },
             { EAspectRatio::Wide, { "16:9", "16:9: locks the game to a widescreen aspect ratio." } },
             { EAspectRatio::Narrow, { "4:3", "4:3: locks the game to a narrow aspect ratio." } },
-            { EAspectRatio::OriginalNarrow, { "ORIGINAL 4:3", "Original 4:3: locks the game to a narrow aspect ratio and retains parity with the game's original implementation." } }
+            { EAspectRatio::OriginalNarrow, { "ORIGINAL 4:3", "Original 4:3: locks the game to a narrow aspect ratio and retains parity with the game's original implementation." } },
+            { EAspectRatio::Custom, { "Custom", "The aspect ratio is set to the values in 'Aspect Width' and 'Aspect Height'." } }
         }
     },
     {
@@ -565,6 +566,7 @@ CONFIG_DEFINE_ENUM_LOCALE(EAspectRatio)
             { EAspectRatio::Wide, { "16:9", "16:9: Stellt das Spiel in einem Breitbildschirm-Vormat dar." } },
             { EAspectRatio::Narrow, { "4:3", "4:3: Stellt das Spiel in einem Mittel-Vormat dar." } },
             { EAspectRatio::OriginalNarrow, { "ORIGINAL 4:3", "Original 4:3: Stellt das Spiel in einem Mittel-Vormat dar, was der ursprünglichen Implementation originalgetreut bleibt." } }
+            { EAspectRatio::Custom, { "Benutzerdefiniert", "Das Seitenverhältnis entspricht den Werten in 'Seitenverhältnis-Breite' und 'Seitenverhältnis-Höhe'." } }
         }
     },
     {
@@ -594,6 +596,18 @@ CONFIG_DEFINE_ENUM_LOCALE(EAspectRatio)
             { EAspectRatio::OriginalNarrow, { "4:3 ORIGINALE", "4:3 Originale: blocca il gioco a un rapporto d'aspetto stretto e mantiene la parità con l'implementazione originale del gioco." } }
         }
     }
+};
+
+CONFIG_DEFINE_LOCALE(AspectWidth)
+{
+    { ELanguage::English, { "Aspect Width", "Adjust aspect width for custom aspect ratios." } },
+    { ELanguage::German,  { "Seitenverhältnis-Breite", "Passe die Breite für benutzerdefinierte Seitenverhältnisse an." } }
+};
+
+CONFIG_DEFINE_LOCALE(AspectHeight)
+{
+    { ELanguage::English, { "Aspect Height", "Adjust aspect height for custom aspect ratios." } },
+    { ELanguage::German,  { "Seitenverhältnis-Höhe", "Passe die Höhe für benutzerdefinierte Seitenverhältnisse an." } }
 };
 
 // Japanese Notes: This localization should include furigana.

--- a/UnleashedRecomp/ui/options_menu.cpp
+++ b/UnleashedRecomp/ui/options_menu.cpp
@@ -1266,6 +1266,8 @@ static void DrawConfigOptions()
             DrawConfigOption(rowCount++, yOffset, &Config::Monitor, canChangeMonitor, monitorReason, 0, 0, displayCount - 1, false);
 
             DrawConfigOption(rowCount++, yOffset, &Config::AspectRatio, true);
+            DrawConfigOption(rowCount++, yOffset, &Config::AspectWidth, true, nullptr, 1, 50, 100);
+            DrawConfigOption(rowCount++, yOffset, &Config::AspectHeight, true, nullptr, 1, 50, 100);
             DrawConfigOption(rowCount++, yOffset, &Config::ResolutionScale, true, nullptr, 0.25f, 1.0f, 2.0f);
             DrawConfigOption(rowCount++, yOffset, &Config::Fullscreen, true);
             DrawConfigOption(rowCount++, yOffset, &Config::VSync, true);

--- a/UnleashedRecomp/user/config.cpp
+++ b/UnleashedRecomp/user/config.cpp
@@ -322,6 +322,7 @@ CONFIG_DEFINE_ENUM_TEMPLATE(EAspectRatio)
     { "16:9", EAspectRatio::Wide },
     { "4:3",  EAspectRatio::Narrow },
     { "Original 4:3",  EAspectRatio::OriginalNarrow },
+    { "Custom",  EAspectRatio::Custom },
 };
 
 CONFIG_DEFINE_ENUM_TEMPLATE(ETripleBuffering)

--- a/UnleashedRecomp/user/config.h
+++ b/UnleashedRecomp/user/config.h
@@ -84,7 +84,8 @@ enum class EAspectRatio : uint32_t
     Auto,
     Wide,
     Narrow,
-    OriginalNarrow
+    OriginalNarrow,
+    Custom
 };
 
 enum class ETripleBuffering : uint32_t

--- a/UnleashedRecomp/user/config_def.h
+++ b/UnleashedRecomp/user/config_def.h
@@ -56,6 +56,8 @@ CONFIG_DEFINE("Video", int32_t, WindowHeight, 720);
 CONFIG_DEFINE_ENUM("Video", EWindowState, WindowState, EWindowState::Normal);
 CONFIG_DEFINE_LOCALISED("Video", int32_t, Monitor, 0);
 CONFIG_DEFINE_ENUM_LOCALISED("Video", EAspectRatio, AspectRatio, EAspectRatio::Auto);
+CONFIG_DEFINE_LOCALISED("Video", int32_t, AspectWidth, 16);
+CONFIG_DEFINE_LOCALISED("Video", int32_t, AspectHeight, 9);
 CONFIG_DEFINE_LOCALISED("Video", float, ResolutionScale, 1.0f);
 CONFIG_DEFINE_LOCALISED("Video", bool, Fullscreen, true);
 CONFIG_DEFINE_LOCALISED("Video", bool, VSync, true);


### PR DESCRIPTION
Sometimes you want your game aspect ratio to be different from your monitor.
It was already possible to do in windowed-mode by resizing, but this enables it for fullscreen mode as well.

- This will still need translations for any language that is not English or German.
- "Portrait" aspect ratios lead to artifacts at the bottom of the screen while boosting. That is also the case in windowed mode.