### PR TITLE
Update dumping guide for external USB storage

### DIFF
--- a/docs/DUMPING-en.md
+++ b/docs/DUMPING-en.md
@@ -60,7 +60,7 @@
 14. Navigate to `/Content/Cache/` and click the **Name** column to sort by name. Look for a file that begins with `TU_19KA20I`, this is the title update which is required for installation.
 
 > [!NOTE]
-> If you're using a USB storage device, you will need to navigate to `/System Cache/Cache/` instead.
+> If you're using an external USB storage device, you will need to navigate to `/System Cache/Cache/` instead.
 
 > [!TIP]
 > If you wish to verify that the contents of this file are correct, you may double-click on it to open it in **Package Viewer** and confirm that `default.xexp` exists inside, along with a folder called `work`.


### PR DESCRIPTION
Slightly changes the wording on the dumping guide to reflect the fact that external USB devices can be used to dump the game's contents as well and not just the Xbox 360 Hard Drive. Also adds a note at step 14 as the Title Update for the game is located in a different directory on external devices.