### PR TITLE
Prevent game from closing whilst autosaving

### DIFF
--- a/UnleashedRecomp/app.h
+++ b/UnleashedRecomp/app.h
@@ -8,6 +8,7 @@ public:
     static inline bool s_isInit;
     static inline bool s_isMissingDLC;
     static inline bool s_isLoading;
+    static inline bool s_isSaving;
     static inline bool s_isWerehog;
     static inline bool s_isSaveDataCorrupt;
 

--- a/UnleashedRecomp/patches/resident_patches.cpp
+++ b/UnleashedRecomp/patches/resident_patches.cpp
@@ -97,6 +97,8 @@ PPC_FUNC(sub_824E5170)
 
     __imp__sub_824E5170(ctx, base);
 
+    App::s_isSaving = pSaveIcon->m_IsVisible;
+
     if (pSaveIcon->m_IsVisible)
     {
         App::s_isSaveDataCorrupt = false;

--- a/UnleashedRecomp/ui/game_window.cpp
+++ b/UnleashedRecomp/ui/game_window.cpp
@@ -34,8 +34,14 @@ int Window_OnSDLEvent(void*, SDL_Event* event)
     switch (event->type)
     {
         case SDL_QUIT:
+        {
+            if (App::s_isSaving)
+                break;
+
             App::Exit();
+
             break;
+        }
 
         case SDL_KEYDOWN:
         {


### PR DESCRIPTION
Not a perfect solution for mitigating save data corruption, for that we'd want backups of `SYS-DATA` created before writing to the main file.

This should prevent corruption by casually closing the game whilst it's saving at least.