### PR TITLE
Face Button follows Positional Button layout instead of Labels

### DIFF
--- a/UnleashedRecomp/hid/driver/sdl_hid.cpp
+++ b/UnleashedRecomp/hid/driver/sdl_hid.cpp
@@ -310,6 +310,7 @@ void hid::Init()
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE, "1");
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_WII, "1");
     SDL_SetHint(SDL_HINT_XINPUT_ENABLED, "1");
+    SDL_SetHint(SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS, "0");
 
     SDL_InitSubSystem(SDL_INIT_EVENTS);
     SDL_AddEventWatch(HID_OnSDLEvent, nullptr);

--- a/UnleashedRecomp/hid/driver/sdl_hid.cpp
+++ b/UnleashedRecomp/hid/driver/sdl_hid.cpp
@@ -310,7 +310,7 @@ void hid::Init()
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE, "1");
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_WII, "1");
     SDL_SetHint(SDL_HINT_XINPUT_ENABLED, "1");
-    SDL_SetHint(SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS, "0");
+    SDL_SetHint(SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS, "0"); // Uses button positions as opposed to labels. This hint is disabled for Nintendo Controllers.
 
     SDL_InitSubSystem(SDL_INIT_EVENTS);
     SDL_AddEventWatch(HID_OnSDLEvent, nullptr);

--- a/UnleashedRecomp/hid/driver/sdl_hid.cpp
+++ b/UnleashedRecomp/hid/driver/sdl_hid.cpp
@@ -310,6 +310,7 @@ void hid::Init()
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE, "1");
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_WII, "1");
     SDL_SetHint(SDL_HINT_XINPUT_ENABLED, "1");
+    
     SDL_SetHint(SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS, "0"); // Uses Button Labels. This hint is disabled for Nintendo Controllers.
 
     SDL_InitSubSystem(SDL_INIT_EVENTS);

--- a/UnleashedRecomp/hid/driver/sdl_hid.cpp
+++ b/UnleashedRecomp/hid/driver/sdl_hid.cpp
@@ -310,7 +310,7 @@ void hid::Init()
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS5_RUMBLE, "1");
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_WII, "1");
     SDL_SetHint(SDL_HINT_XINPUT_ENABLED, "1");
-    SDL_SetHint(SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS, "0"); // Uses button positions as opposed to labels. This hint is disabled for Nintendo Controllers.
+    SDL_SetHint(SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS, "0"); // Uses Button Labels. This hint is disabled for Nintendo Controllers.
 
     SDL_InitSubSystem(SDL_INIT_EVENTS);
     SDL_AddEventWatch(HID_OnSDLEvent, nullptr);


### PR DESCRIPTION
what `SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS` does is that SDL's Controller API will follow on Button Labels, by default: it is set to `1`. Consequences: the modern Nintendo Switch layout will be using the Nintendo Layout across Menu Navigation and Gameplay. 

> ```
>      (Y)              (X)
>   (X)   (B)        (Y)   (A)
>      (A)              (B)
> 
>   Standard         Nintendo
> ```


In the case of Sonic Unleashed: every single part of the game will be using Nintendo Layout, thus between the Daytime and Night time stages will make the gameplay much harder than it really is due to muscle memory. This will require Nintendo users to rely on a Button Remapping solution *just* to correct it.

This pull request is essentially a simple hack that adds `SDL_HINT_GAMECONTROLLER_USE_BUTTON_LABELS` on `hid::Init` list and set the value to 0. Forcing the game to use the Positional Layout across all controllers, SDL3-style. The only downside is that for older Nintendo controllers like Wii family of controllers, GameCube or even SEGA Controllers; it'll will also follow the Face Button Positional layout. ([refer to SDL_GameControllerDB's Mapping Guide](https://github.com/mdqinc/SDL_GameControllerDB#mapping-guide))

 Until Nintendo Switch controller support gets properly added (which for some reason: `SDL_HINT_JOYSTICK_HIDAPI_SWITCH` is missing) and/or Action Remapping gets added, this is considered a **temporary fix** on https://github.com/hedge-dev/UnleashedRecomp/issues/488, as it'll make Nintendo controllers use the Positional layout instead of the Labeled layout.
