### PR TITLE
Moved game data folder to ~/.local/share/UnleashedRecomp in non-flatpak scenarios

### DIFF
--- a/UnleashedRecomp/CMakeLists.txt
+++ b/UnleashedRecomp/CMakeLists.txt
@@ -4,10 +4,6 @@ if (WIN32)
     option(UNLEASHED_RECOMP_D3D12 "Add D3D12 support for rendering" ON)
 endif()
 
-if (CMAKE_SYSTEM_NAME MATCHES "Linux")
-    option(UNLEASHED_RECOMP_FLATPAK "Configure the build for Flatpak compatibility." OFF)
-endif()
-
 function(BIN2C)
     cmake_parse_arguments(BIN2C_ARGS "" "TARGET_OBJ;SOURCE_FILE;DEST_FILE;ARRAY_NAME;COMPRESSION_TYPE" "" ${ARGN})
 
@@ -298,13 +294,6 @@ if (WIN32)
     endif()
 else()
     add_executable(UnleashedRecomp ${UNLEASHED_RECOMP_CXX_SOURCES})
-endif()
-
-if (UNLEASHED_RECOMP_FLATPAK)
-    target_compile_definitions(UnleashedRecomp PRIVATE 
-        "UNLEASHED_RECOMP_FLATPAK"
-        "GAME_INSTALL_DIRECTORY_PREPROC=\"/var/data\""
-    )
 endif()
 
 if (UNLEASHED_RECOMP_D3D12)

--- a/UnleashedRecomp/CMakeLists.txt
+++ b/UnleashedRecomp/CMakeLists.txt
@@ -303,7 +303,7 @@ endif()
 if (UNLEASHED_RECOMP_FLATPAK)
     target_compile_definitions(UnleashedRecomp PRIVATE 
         "UNLEASHED_RECOMP_FLATPAK"
-        "GAME_INSTALL_DIRECTORY=\"/var/data\""
+        "GAME_INSTALL_DIRECTORY_PREPROC=\"/var/data\""
     )
 endif()
 

--- a/UnleashedRecomp/app.cpp
+++ b/UnleashedRecomp/app.cpp
@@ -33,7 +33,7 @@ PPC_FUNC_IMPL(__imp__sub_824EB490);
 PPC_FUNC(sub_824EB490)
 {
     App::s_isInit = true;
-    App::s_isMissingDLC = !Installer::checkAllDLC(GetGamePath());
+    App::s_isMissingDLC = !Installer::checkAllDLC(g_gamepath);
     App::s_language = Config::Language;
 
     SWA::SGlobals::Init();

--- a/UnleashedRecomp/kernel/xam.cpp
+++ b/UnleashedRecomp/kernel/xam.cpp
@@ -315,11 +315,11 @@ uint32_t XamContentCreateEx(uint32_t dwUserIndex, const char* szRootName, const 
             }
             else if (pContentData->dwContentType == XCONTENTTYPE_DLC)
             {
-                root = GAME_INSTALL_DIRECTORY "/dlc";
+                root = g_gamepath + "/dlc";
             }
             else
             {
-                root = GAME_INSTALL_DIRECTORY;
+                root = g_gamepath;
             }
 
             XamRegisterContent(*pContentData, root);

--- a/UnleashedRecomp/main.cpp
+++ b/UnleashedRecomp/main.cpp
@@ -51,8 +51,8 @@ void KiSystemStartup()
 {
     const auto gameContent = XamMakeContent(XCONTENTTYPE_RESERVED, "Game");
     const auto updateContent = XamMakeContent(XCONTENTTYPE_RESERVED, "Update");
-    XamRegisterContent(gameContent, GAME_INSTALL_DIRECTORY "/game");
-    XamRegisterContent(updateContent, GAME_INSTALL_DIRECTORY "/update");
+    XamRegisterContent(gameContent, g_gamepath + "/game");
+    XamRegisterContent(updateContent, g_gamepath + "/update");
 
     const auto saveFilePath = GetSaveFilePath(true);
     bool saveFileExists = std::filesystem::exists(saveFilePath);
@@ -84,7 +84,7 @@ void KiSystemStartup()
     XamContentCreateEx(0, "D", &gameContent, OPEN_EXISTING, nullptr, nullptr, 0, 0, nullptr);
 
     std::error_code ec;
-    for (auto& file : std::filesystem::directory_iterator(GAME_INSTALL_DIRECTORY "/dlc", ec))
+    for (auto& file : std::filesystem::directory_iterator(g_gamepath + "/dlc", ec))
     {
         if (file.is_directory())
         {
@@ -198,7 +198,7 @@ int main(int argc, char *argv[])
     HostStartup();
 
     std::filesystem::path modulePath;
-    bool isGameInstalled = Installer::checkGameInstall(GAME_INSTALL_DIRECTORY, modulePath);
+    bool isGameInstalled = Installer::checkGameInstall(g_gamepath, modulePath);
     bool runInstallerWizard = forceInstaller || forceDLCInstaller || !isGameInstalled;
     if (runInstallerWizard)
     {
@@ -208,7 +208,7 @@ int main(int argc, char *argv[])
             std::_Exit(1);
         }
 
-        if (!InstallerWizard::Run(GAME_INSTALL_DIRECTORY, isGameInstalled && forceDLCInstaller))
+        if (!InstallerWizard::Run(g_gamepath, isGameInstalled && forceDLCInstaller))
         {
             std::_Exit(0);
         }

--- a/UnleashedRecomp/mod/mod_loader.cpp
+++ b/UnleashedRecomp/mod/mod_loader.cpp
@@ -100,7 +100,7 @@ void ModLoader::Init()
     {
         configIni = {};
 
-        if (!configIni.read(GAME_INSTALL_DIRECTORY "/cpkredir.ini"))
+        if (!configIni.read(g_gamepath + "/cpkredir.ini"))
             return;
     }
 

--- a/UnleashedRecomp/user/config.cpp
+++ b/UnleashedRecomp/user/config.cpp
@@ -5,14 +5,15 @@
 
 std::vector<IConfigDef*> g_configDefinitions;
 
+const bool g_isRuntimeFlatpak = 
+#if defined(__linux__)
+    getenv("FLATPAK_SANDBOX_DIR") != nullptr;
+#else
+    false;
+#endif
+
 #define CONFIG_DEFINE_ENUM_TEMPLATE(type) \
     static std::unordered_map<std::string, type> g_##type##_template =
-
-#if defined(__linux__)
-    const bool g_isRuntimeFlatpak = getenv("FLATPAK_SANDBOX_DIR") != nullptr;
-#else
-    const bool g_isRuntimeFlatpak = false;
-#endif
 
 CONFIG_DEFINE_ENUM_TEMPLATE(ELanguage)
 {

--- a/UnleashedRecomp/user/config.cpp
+++ b/UnleashedRecomp/user/config.cpp
@@ -8,6 +8,12 @@ std::vector<IConfigDef*> g_configDefinitions;
 #define CONFIG_DEFINE_ENUM_TEMPLATE(type) \
     static std::unordered_map<std::string, type> g_##type##_template =
 
+#if defined(__linux__)
+    const bool g_isRuntimeFlatpak = getenv("FLATPAK_SANDBOX_DIR") != nullptr;
+#else
+    const bool g_isRuntimeFlatpak = false;
+#endif
+
 CONFIG_DEFINE_ENUM_TEMPLATE(ELanguage)
 {
     { "English",  ELanguage::English },

--- a/UnleashedRecomp/user/config.h
+++ b/UnleashedRecomp/user/config.h
@@ -2,6 +2,8 @@
 
 #include <locale/locale.h>
 
+extern const bool g_isRuntimeFlatpak;
+
 class IConfigDef
 {
 public:

--- a/UnleashedRecomp/user/paths.cpp
+++ b/UnleashedRecomp/user/paths.cpp
@@ -4,32 +4,36 @@
 
 std::filesystem::path g_executableRoot = os::process::GetExecutablePath().remove_filename();
 std::filesystem::path g_userPath = BuildUserPath();
-extern const std::string g_gamepath = GetGamePath().string();
+extern const std::string g_gamepath = GetGamePath();
 
 bool CheckPortable()
 {
     return std::filesystem::exists(g_executableRoot / "portable.txt");
 }
 
-std::filesystem::path GetGamePath()
+std::string GetGamePath()
 {
 #if defined(__linux__)
-    if (g_isRuntimeFlatpak || CheckPortable())
-        return GAME_INSTALL_DIRECTORY_PREPROC;
+    if (g_isRuntimeFlatpak) 
+        return "/var/data";
+    
+    if (CheckPortable())
+        return g_executableRoot.string();
 
     const char* homeDir = getenv("HOME");
+    
     if (homeDir == nullptr)
     {
-        return GAME_INSTALL_DIRECTORY_PREPROC;
+        return g_executableRoot.string();
     }
     else 
     {
         std::filesystem::path homePath = homeDir;
         std::filesystem::path gamePath = homePath / ".local/share" / USER_DIRECTORY;
-        return gamePath;
+        return gamePath.string();
     }
 #else
-    return GAME_INSTALL_DIRECTORY_PREPROC;
+    return ".";
 #endif
 }
 

--- a/UnleashedRecomp/user/paths.cpp
+++ b/UnleashedRecomp/user/paths.cpp
@@ -1,12 +1,36 @@
 #include "paths.h"
+#include <user/config.h>
 #include <os/process.h>
 
 std::filesystem::path g_executableRoot = os::process::GetExecutablePath().remove_filename();
 std::filesystem::path g_userPath = BuildUserPath();
+extern const std::string g_gamepath = GetGamePath().string();
 
 bool CheckPortable()
 {
     return std::filesystem::exists(g_executableRoot / "portable.txt");
+}
+
+std::filesystem::path GetGamePath()
+{
+#if defined(__linux__)
+    if (g_isRuntimeFlatpak || CheckPortable())
+        return GAME_INSTALL_DIRECTORY_PREPROC;
+
+    const char* homeDir = getenv("HOME");
+    if (homeDir == nullptr)
+    {
+        return GAME_INSTALL_DIRECTORY_PREPROC;
+    }
+    else 
+    {
+        std::filesystem::path homePath = homeDir;
+        std::filesystem::path gamePath = homePath / ".local/share" / USER_DIRECTORY;
+        return gamePath;
+    }
+#else
+    return GAME_INSTALL_DIRECTORY_PREPROC;
+#endif
 }
 
 std::filesystem::path BuildUserPath()

--- a/UnleashedRecomp/user/paths.h
+++ b/UnleashedRecomp/user/paths.h
@@ -4,15 +4,11 @@
 
 #define USER_DIRECTORY "UnleashedRecomp"
 
-#ifndef GAME_INSTALL_DIRECTORY_PREPROC
-#define GAME_INSTALL_DIRECTORY_PREPROC "."
-#endif
-
 bool CheckPortable();
 std::filesystem::path BuildUserPath();
 const std::filesystem::path& GetUserPath();
 extern const std::string g_gamepath;
-std::filesystem::path GetGamePath();
+std::string GetGamePath();
 
 inline std::filesystem::path GetSavePath(bool checkForMods)
 {

--- a/UnleashedRecomp/user/paths.h
+++ b/UnleashedRecomp/user/paths.h
@@ -4,18 +4,15 @@
 
 #define USER_DIRECTORY "UnleashedRecomp"
 
-#ifndef GAME_INSTALL_DIRECTORY
-#define GAME_INSTALL_DIRECTORY "."
+#ifndef GAME_INSTALL_DIRECTORY_PREPROC
+#define GAME_INSTALL_DIRECTORY_PREPROC "."
 #endif
-
-inline std::filesystem::path GetGamePath()
-{
-    return GAME_INSTALL_DIRECTORY;
-}
 
 bool CheckPortable();
 std::filesystem::path BuildUserPath();
 const std::filesystem::path& GetUserPath();
+extern const std::string g_gamepath;
+std::filesystem::path GetGamePath();
 
 inline std::filesystem::path GetSavePath(bool checkForMods)
 {

--- a/flatpak/io.github.hedge_dev.unleashedrecomp.json
+++ b/flatpak/io.github.hedge_dev.unleashedrecomp.json
@@ -20,7 +20,7 @@
       "name": "UnleashedRecomp",
       "buildsystem": "simple",
       "build-commands": [
-        "cmake --preset linux-release -DUNLEASHED_RECOMP_FLATPAK=ON -DSDL2MIXER_VORBIS=VORBISFILE -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache",
+        "cmake --preset linux-release -DSDL2MIXER_VORBIS=VORBISFILE -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache",
         "cmake --build out/build/linux-release --target UnleashedRecomp",
         "mkdir -p /app/bin",
         "cp out/build/linux-release/UnleashedRecomp/UnleashedRecomp /app/bin/UnleashedRecomp",


### PR DESCRIPTION
When the application is launched as a standalone executable, or gets extracted from the flatpak container it's packed into, it will use the local `~/.local/share/UnleashedRecomp` folder instead of placing the game data on the current working directory.

This solves two issues:
- Using the current working directory, as per the current behaviour, is unrealiable, as it can easily change (for example, by simply launching the game through the terminal from a different directory
- Solves https://github.com/hedge-dev/UnleashedRecomp/issues/1099 and allows the executable to be repackaged in Linux

It's still possible to have the game data in the same folder as the executable by using the `portable.txt` file.

Behaviour remains unchanged under flatpak