### PR TITLE
Rename DisableDPadAsAnalogInput to DisableDPadMovement

### DIFF
--- a/UnleashedRecomp/patches/input_patches.cpp
+++ b/UnleashedRecomp/patches/input_patches.cpp
@@ -212,7 +212,7 @@ g_sdlEventListenerForInputPatches;
 
 static bool IsDPadThreshold(const SWA::SPadState* pPadState)
 {
-    if (Config::DisableDPadAsAnalogInput)
+    if (Config::DisableDPadMovement)
         return false;
 
     return pPadState->IsDown(SWA::eKeyState_DpadUp)   ||
@@ -240,7 +240,7 @@ static bool IsCursorThreshold(double deadzone = 0, bool isBelowThreshold = false
 
 static void SetDPadAnalogDirectionX(PPCRegister& pPadState, PPCRegister& x, bool invert, float max = 1.0f)
 {
-    if (Config::DisableDPadAsAnalogInput)
+    if (Config::DisableDPadMovement)
         return;
 
     auto pGuestPadState = (SWA::SPadState*)g_memory.Translate(pPadState.u32);
@@ -254,7 +254,7 @@ static void SetDPadAnalogDirectionX(PPCRegister& pPadState, PPCRegister& x, bool
 
 static void SetDPadAnalogDirectionY(PPCRegister& pPadState, PPCRegister& y, bool invert, float max = 1.0f)
 {
-    if (Config::DisableDPadAsAnalogInput)
+    if (Config::DisableDPadMovement)
         return;
 
     auto pGuestPadState = (SWA::SPadState*)g_memory.Translate(pPadState.u32);
@@ -292,7 +292,7 @@ void PostureDPadSupportYMidAsmHook(PPCRegister& pPadState, PPCRegister& y)
 
 void PostureSpaceHurrierDPadSupportXMidAsmHook(PPCRegister& pPadState, PPCVRegister& vector)
 {
-    if (Config::DisableDPadAsAnalogInput)
+    if (Config::DisableDPadMovement)
         return;
     
     auto pGuestPadState = (SWA::SPadState*)g_memory.Translate(pPadState.u32);
@@ -306,7 +306,7 @@ void PostureSpaceHurrierDPadSupportXMidAsmHook(PPCRegister& pPadState, PPCVRegis
 
 void PostureSpaceHurrierDPadSupportYMidAsmHook(PPCRegister& pPadState, PPCVRegister& vector)
 {
-    if (Config::DisableDPadAsAnalogInput)
+    if (Config::DisableDPadMovement)
         return;
 
     auto pGuestPadState = (SWA::SPadState*)g_memory.Translate(pPadState.u32);
@@ -430,7 +430,7 @@ PPC_FUNC(sub_8256C938)
         pWorldMapCursor->m_LeftStickVertical = rPadState.LeftStickVertical;
         pWorldMapCursor->m_LeftStickHorizontal = rPadState.LeftStickHorizontal;
 
-        if (!Config::DisableDPadAsAnalogInput)
+        if (!Config::DisableDPadMovement)
         {
             if (rPadState.IsDown(SWA::eKeyState_DpadUp))
                 pWorldMapCursor->m_LeftStickVertical = 1.0f;

--- a/UnleashedRecomp/user/config_def.h
+++ b/UnleashedRecomp/user/config_def.h
@@ -79,7 +79,9 @@ CONFIG_DEFINE_HIDDEN("Codes", bool, AllowCancellingUnleash, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, DisableAutoSaveWarning, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, DisableBoostFilter, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, DisableDLCIcon, false);
+CONFIG_DEFINE_HIDDEN("Codes", bool, DisableDPadMovement, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, DisableDWMRoundedCorners, false);
+CONFIG_DEFINE_HIDDEN("Codes", bool, DisableLowResolutionFontOnCustomUI, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, EnableEventCollisionDebugView, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, EnableGIMipLevelDebugView, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, EnableObjectCollisionDebugView, false);
@@ -92,7 +94,5 @@ CONFIG_DEFINE_HIDDEN("Codes", bool, SaveScoreAtCheckpoints, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, SkipIntroLogos, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, UseArrowsForTimeOfDayTransition, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, UseOfficialTitleOnTitleBar, false);
-CONFIG_DEFINE_HIDDEN("Codes", bool, DisableLowResolutionFontOnCustomUI, false);
-CONFIG_DEFINE_HIDDEN("Codes", bool, DisableDPadAsAnalogInput, false);
 
 CONFIG_DEFINE("Update", time_t, LastChecked, 0);


### PR DESCRIPTION
The original option name was "Allow D-Pad Movement" before being removed, I forgot to note this before approving the PR that merged the code in to disable it.