### PR TITLE
Fix packing ZIP inside a ZIP in Windows CI pipeline

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -145,13 +145,11 @@ jobs:
           Move-Item -Path ".\out\build\${{ env.CMAKE_PRESET }}\UnleashedRecomp\dxil.dll" -Destination ".\release\dxil.dll"
           Move-Item -Path ".\out\build\${{ env.CMAKE_PRESET }}\UnleashedRecomp\UnleashedRecomp.exe" -Destination ".\release\UnleashedRecomp.exe"
 
-          Compress-Archive -Path .\release\* -DestinationPath .\UnleashedRecomp-Windows.zip
-
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: UnleashedRecomp-Windows-${{ env.CMAKE_PRESET }}
-          path: .\UnleashedRecomp-Windows.zip
+          path: .\release
 
       - name: Upload PDB
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This PR should fix Windows build artifacts having a zip file inside another zip file.