### PR TITLE
Added code to force the alternate game title

### DIFF
--- a/UnleashedRecomp/patches/misc_patches.cpp
+++ b/UnleashedRecomp/patches/misc_patches.cpp
@@ -53,6 +53,16 @@ void WerehogBattleMusicMidAsmHook(PPCRegister& r11)
         r11.u8 = 3;
 }
 
+bool UseAlternateTitleMidAsmHook()
+{
+    auto isSWA = Config::Language == ELanguage::Japanese;
+
+    if (Config::UseAlternateTitle)
+        isSWA = !isSWA;
+
+    return isSWA;
+}
+
 /* Hook function that gets the game region
    and force result to zero for Japanese
    to display the correct logos. */

--- a/UnleashedRecomp/ui/game_window.cpp
+++ b/UnleashedRecomp/ui/game_window.cpp
@@ -282,7 +282,12 @@ const char* GameWindow::GetTitle()
 {
     if (Config::UseOfficialTitleOnTitleBar)
     {
-        return Config::Language == ELanguage::Japanese
+        auto isSWA = Config::Language == ELanguage::Japanese;
+
+        if (Config::UseAlternateTitle)
+            isSWA = !isSWA;
+
+        return isSWA
             ? "SONIC WORLD ADVENTURE"
             : "SONIC UNLEASHED";
     }

--- a/UnleashedRecomp/user/config_def.h
+++ b/UnleashedRecomp/user/config_def.h
@@ -92,6 +92,7 @@ CONFIG_DEFINE_HIDDEN("Codes", bool, HomingAttackOnJump, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, HUDToggleKey, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, SaveScoreAtCheckpoints, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, SkipIntroLogos, false);
+CONFIG_DEFINE_HIDDEN("Codes", bool, UseAlternateTitle, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, UseArrowsForTimeOfDayTransition, false);
 CONFIG_DEFINE_HIDDEN("Codes", bool, UseOfficialTitleOnTitleBar, false);
 

--- a/UnleashedRecompLib/config/SWA.toml
+++ b/UnleashedRecompLib/config/SWA.toml
@@ -1105,3 +1105,9 @@ registers = ["r3"]
 name = "DisableBoostFilterMidAsmHook"
 address = 0x82B48C9C
 registers = ["r11"]
+
+[[midasm_hook]]
+name = "UseAlternateTitleMidAsmHook"
+address = 0x82580F44
+jump_address_on_true = 0x82580F48
+jump_address_on_false = 0x82580FA0


### PR DESCRIPTION
When enabled with any language other than Japanese, the game title will be SONIC WORLD ADVENTURE. If the language is Japanese, the game title will be SONIC UNLEASHED.

Closes https://github.com/hedge-dev/UnleashedRecomp/issues/1196.