### PR TITLE
Fix alignment of shop title and ring count for village shop/hotdog stands

### DIFF
--- a/UnleashedRecomp/patches/aspect_ratio_patches.cpp
+++ b/UnleashedRecomp/patches/aspect_ratio_patches.cpp
@@ -711,8 +711,6 @@ static const xxHashMap<CsdModifier> g_modifiers =
 
     // ui_shop
     { HashStr("ui_shop/footer/shop_footer"), { ALIGN_BOTTOM } },
-    { HashStr("ui_shop/header/ring"), { ALIGN_TOP } },
-    { HashStr("ui_shop/header/shop_nametag"), { ALIGN_TOP } },
 
     // ui_start
     { HashStr("ui_start/Clear/position/bg/bg_1"), { STRETCH } },


### PR DESCRIPTION
Whilst it would be possible to make the Name Tag follow the background element for it for shops/hotdog stands, with the current implementation it makes the most sense for narrow UIs to center these elements, as the rest of the UI scene (excluding the button guides) is centered too.

![image](https://github.com/user-attachments/assets/49316dc3-c6cc-4ff9-b18c-8593bb2ceffd)

Fixes #1373.