### PR TITLE
Prohibit Channel Configuration changes during gameplay

### DIFF
--- a/UnleashedRecomp/apu/audio.h
+++ b/UnleashedRecomp/apu/audio.h
@@ -10,7 +10,6 @@
 void XAudioInitializeSystem();
 void XAudioRegisterClient(PPCFunc* callback, uint32_t param);
 void XAudioSubmitFrame(void* samples);
-void XAudioConfigValueChangedCallback(class IConfigDef* configDef);
 
 uint32_t XAudioRegisterRenderDriverClient(be<uint32_t>* callback, be<uint32_t>* driver);
 uint32_t XAudioUnregisterRenderDriverClient(uint32_t driver);

--- a/UnleashedRecomp/apu/driver/sdl2_driver.cpp
+++ b/UnleashedRecomp/apu/driver/sdl2_driver.cpp
@@ -150,18 +150,3 @@ void XAudioSubmitFrame(void* samples)
         SDL_QueueAudio(g_audioDevice, &audioFrames, sizeof(audioFrames));
     }
 }
-
-void XAudioConfigValueChangedCallback(IConfigDef* configDef)
-{
-    if (configDef == &Config::ChannelConfiguration)
-    {
-        if (g_audioThread->joinable())
-        {
-            g_audioThreadShouldExit = true;
-            g_audioThread->join();
-        }
-
-        CreateAudioDevice();
-        CreateAudioThread();
-    }
-}

--- a/UnleashedRecomp/ui/options_menu.cpp
+++ b/UnleashedRecomp/ui/options_menu.cpp
@@ -98,6 +98,7 @@ static bool g_isEnterKeyBuffered = false;
 static bool g_canReset = false;
 static bool g_isLanguageOptionChanged = false;
 static bool g_titleAnimBegin = true;
+static EChannelConfiguration g_currentChannelConfig;
 
 static double g_appearTime = 0.0;
 
@@ -802,7 +803,6 @@ static void DrawConfigOption(int32_t rowIndex, float yOffset, ConfigDef<T>* conf
                             config->Callback(config);
 
                         VideoConfigValueChangedCallback(config);
-                        XAudioConfigValueChangedCallback(config);
 
                         Game_PlaySound("sys_worldmap_finaldecide");
                     }
@@ -835,7 +835,6 @@ static void DrawConfigOption(int32_t rowIndex, float yOffset, ConfigDef<T>* conf
                             if (config->Value != s_oldValue)
                             {
                                 VideoConfigValueChangedCallback(config);
-                                XAudioConfigValueChangedCallback(config);
 
                                 if (config->ApplyCallback)
                                     config->ApplyCallback(config);
@@ -864,7 +863,6 @@ static void DrawConfigOption(int32_t rowIndex, float yOffset, ConfigDef<T>* conf
                         config->MakeDefault();
 
                         VideoConfigValueChangedCallback(config);
-                        XAudioConfigValueChangedCallback(config);
 
                         if (config->Callback)
                             config->Callback(config);
@@ -1245,7 +1243,7 @@ static void DrawConfigOptions()
             DrawConfigOption(rowCount++, yOffset, &Config::MasterVolume, true);
             DrawConfigOption(rowCount++, yOffset, &Config::MusicVolume, true);
             DrawConfigOption(rowCount++, yOffset, &Config::EffectsVolume, true);
-            DrawConfigOption(rowCount++, yOffset, &Config::ChannelConfiguration, true);
+            DrawConfigOption(rowCount++, yOffset, &Config::ChannelConfiguration, !OptionsMenu::s_isPause, cmnReason);
             DrawConfigOption(rowCount++, yOffset, &Config::MusicAttenuation, AudioPatches::CanAttenuate(), &Localise("Options_Desc_OSNotSupported"));
             DrawConfigOption(rowCount++, yOffset, &Config::BattleTheme, true);
             break;
@@ -1786,7 +1784,7 @@ void OptionsMenu::Draw()
             DrawFadeTransition();
     }
 
-    s_isRestartRequired = Config::Language != App::s_language;
+    s_isRestartRequired = Config::Language != App::s_language || Config::ChannelConfiguration != g_currentChannelConfig;
 }
 
 void OptionsMenu::Open(bool isPause, SWA::EMenuType pauseMenuType)
@@ -1802,6 +1800,7 @@ void OptionsMenu::Open(bool isPause, SWA::EMenuType pauseMenuType)
     g_categoryAnimMax = { 0.0f, 0.0f };
     g_selectedItem = nullptr;
     g_titleAnimBegin = true;
+    g_currentChannelConfig = Config::ChannelConfiguration;
 
     /* Store button state so we can track it later
        and prevent the first item being selected. */


### PR DESCRIPTION
This only allows Channel Configuration to be changed at the title screen options menu, so it forces the game to restart after changing it as a workaround for more channels not being created at runtime.

It also removes the audio config changed callbacks to prevent audio crunching when changing the option, only for it to apply on restart anyway.

Closes https://github.com/hedge-dev/UnleashedRecomp/issues/592.