### PR TITLE
Enable use of xdg-desktop-portal on linux flatpak builds

### DIFF
--- a/flatpak/io.github.hedge_dev.unleashedrecomp.json
+++ b/flatpak/io.github.hedge_dev.unleashedrecomp.json
@@ -20,7 +20,7 @@
       "name": "UnleashedRecomp",
       "buildsystem": "simple",
       "build-commands": [
-        "cmake --preset linux-release -DUNLEASHED_RECOMP_FLATPAK=ON -DSDL2MIXER_VORBIS=VORBISFILE -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache",
+        "cmake --preset linux-release -DUNLEASHED_RECOMP_FLATPAK=ON -DNFD_PORTAL=ON -DSDL2MIXER_VORBIS=VORBISFILE -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER_LAUNCHER=ccache",
         "cmake --build out/build/linux-release --target UnleashedRecomp",
         "mkdir -p /app/bin",
         "cp out/build/linux-release/UnleashedRecomp/UnleashedRecomp /app/bin/UnleashedRecomp",


### PR DESCRIPTION
This commit enables the use of the portal API for flatpak builds on linux: https://docs.flatpak.org/en/latest/portal-api-reference.html

Specifically for Unleashed Recompiled, this makes the installer use the native file dialog instead of the default gtk one.

As a collateral, this should fix https://github.com/hedge-dev/UnleashedRecomp/issues/553, as the file dialog will avoid using the gtk library altogether. I need the affected people to try this fix, however, as I am not able to reproduce the original bug consistently.