### PR TITLE
Check if the 4 GB memory allocation failed.

### DIFF
--- a/UnleashedRecomp/gpu/video.cpp
+++ b/UnleashedRecomp/gpu/video.cpp
@@ -2013,6 +2013,12 @@ static uint32_t CreateDevice(uint32_t a1, uint32_t a2, uint32_t a3, uint32_t a4,
     // Move backbuffer to guest memory.
     assert(!g_memory.IsInMemoryRange(g_backBuffer) && g_backBufferHolder != nullptr);
     g_backBuffer = g_userHeap.AllocPhysical<GuestSurface>(std::move(*g_backBufferHolder));
+
+    // Check for stale reference. BeginCommandList() gets called before CreateDevice() which is where the assignment happens.
+    if (g_renderTarget == g_backBufferHolder.get()) g_renderTarget = g_backBuffer;
+    if (g_depthStencil == g_backBufferHolder.get()) g_depthStencil = g_backBuffer;
+
+    // Free the host backbuffer.
     g_backBufferHolder = nullptr;
 
     auto device = g_userHeap.AllocPhysical<GuestDevice>();

--- a/UnleashedRecomp/gpu/video.cpp
+++ b/UnleashedRecomp/gpu/video.cpp
@@ -320,6 +320,7 @@ static constexpr RenderFormat BACKBUFFER_FORMAT = RenderFormat::B8G8R8A8_UNORM;
 static std::unique_ptr<RenderCommandSemaphore> g_acquireSemaphores[NUM_FRAMES];
 static std::unique_ptr<RenderCommandSemaphore> g_renderSemaphores[NUM_FRAMES];
 static uint32_t g_backBufferIndex;
+static std::unique_ptr<GuestSurface> g_backBufferHolder;
 static GuestSurface* g_backBuffer;
 
 static std::unique_ptr<RenderTexture> g_intermediaryBackBufferTexture;
@@ -1948,7 +1949,10 @@ bool Video::CreateHostDevice(const char *sdlVideoDriver)
     desc.renderTargetCount = 1;
     g_gammaCorrectionPipeline = g_device->createGraphicsPipeline(desc);
 
-    g_backBuffer = g_userHeap.AllocPhysical<GuestSurface>(ResourceType::RenderTarget);
+    // NOTE: We initially allocate this on host memory to make the installer work, even if the 4 GB memory allocation fails.
+    g_backBufferHolder = std::make_unique<GuestSurface>(ResourceType::RenderTarget);
+
+    g_backBuffer = g_backBufferHolder.get();
     g_backBuffer->width = 1280;
     g_backBuffer->height = 720;
     g_backBuffer->format = BACKBUFFER_FORMAT;
@@ -2005,6 +2009,11 @@ static uint32_t CreateDevice(uint32_t a1, uint32_t a2, uint32_t a3, uint32_t a4,
         g_xdbfTextureCache[achievement.ID] =
             LoadTexture((uint8_t *)achievement.pImageBuffer, achievement.ImageBufferSize).release();
     }
+
+    // Move backbuffer to guest memory.
+    assert(!g_memory.IsInMemoryRange(g_backBuffer) && g_backBufferHolder != nullptr);
+    g_backBuffer = g_userHeap.AllocPhysical<GuestSurface>(std::move(*g_backBufferHolder));
+    g_backBufferHolder = nullptr;
 
     auto device = g_userHeap.AllocPhysical<GuestDevice>();
     memset(device, 0, sizeof(*device));

--- a/UnleashedRecomp/kernel/memory.cpp
+++ b/UnleashedRecomp/kernel/memory.cpp
@@ -9,6 +9,9 @@ Memory::Memory()
     if (base == nullptr)
         base = (uint8_t*)VirtualAlloc(nullptr, PPC_MEMORY_SIZE, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
 
+    if (base == nullptr)
+        return;
+
     DWORD oldProtect;
     VirtualProtect(base, 4096, PAGE_NOACCESS, &oldProtect);
 #else
@@ -16,6 +19,9 @@ Memory::Memory()
 
     if (base == (uint8_t*)MAP_FAILED)
         base = (uint8_t*)mmap(NULL, PPC_MEMORY_SIZE, PROT_READ | PROT_WRITE, MAP_ANON | MAP_PRIVATE, -1, 0);
+
+    if (base == nullptr)
+        return;
 
     mprotect(base, 4096, PROT_NONE);
 #endif

--- a/UnleashedRecomp/locale/locale.cpp
+++ b/UnleashedRecomp/locale/locale.cpp
@@ -707,11 +707,11 @@ std::unordered_map<std::string_view, std::unordered_map<ELanguage, std::string>>
         "System_MemoryAllocationFailed",
         {
             { ELanguage::English,  "Failed to allocate game memory.\n\nPlease make sure that:\n\n- You meet the minimum system requirements (8 GB).\n- Your page file is configured with at least 4-8 GB of virtual memory." },
-            { ELanguage::Japanese, "" },
-            { ELanguage::German,   "" },
-            { ELanguage::French,   "" },
-            { ELanguage::Spanish,  "" },
-            { ELanguage::Italian,  "" }
+            { ELanguage::Japanese, "ゲームメモリの割り当てに失敗しました\n\n次の点を確認してください：\n\n※最小システム要件（8 GB）を満たしていること。\n※ページファイルに少なくとも4～8 GBの仮想メモリが設定されていること" },
+            { ELanguage::German,   "Fehler beim Zuweisen des Spielspeichers.\n\nBitte stelle sicher, dass:\n\n- Die Mindestanforderungen für das System erfüllt sind (8 GB).\n- Die Auslagerungsdatei mit mindestens 4-8 GB virtuellem Speicher konfiguriert ist." },
+            { ELanguage::French,   "Échec d'allocation de la mémoire du jeu.\n\nVeuillez vous assurer que :\n\n- Vous disposez de la configuration minimale requise (8 Go).\n- Votre fichier d’échange est configuré avec au moins 4 à 8 Go de mémoire virtuelle." },
+            { ELanguage::Spanish,  "Fallo al asignar memoria del juego.\n\nPor favor, asegúrate de que:\n\n- Cumples los requisitos mínimos del sistema (8 GB).\n- Tu archivo de páginación está configurado con al menos 4 u 8 GB de memoria virtual." },
+            { ELanguage::Italian,  "Impossibile allocare la memoria per il gioco.\n\nAssicurati che:\n\n- Soddisfi i requisiti minimi di sistema (8 GB).\n- Il tuo file di paging sia configurato con almeno 4 o 8 GB di memoria virtuale." }
         }
     },
     {

--- a/UnleashedRecomp/locale/locale.cpp
+++ b/UnleashedRecomp/locale/locale.cpp
@@ -706,7 +706,7 @@ std::unordered_map<std::string_view, std::unordered_map<ELanguage, std::string>>
     {
         "System_MemoryAllocationFailed",
         {
-            { ELanguage::English,  "Memory allocation failed blablabla enable your pagefile, ensure it's minimum 4 or 8 GB blablablabla" },
+            { ELanguage::English,  "Failed to allocate game memory.\n\nPlease make sure that:\n\n- You meet the minimum system requirements (8 GB).\n- Your pagefile is configured with at least 4-8 GB of virtual memory." },
             { ELanguage::Japanese, "" },
             { ELanguage::German,   "" },
             { ELanguage::French,   "" },

--- a/UnleashedRecomp/locale/locale.cpp
+++ b/UnleashedRecomp/locale/locale.cpp
@@ -706,7 +706,7 @@ std::unordered_map<std::string_view, std::unordered_map<ELanguage, std::string>>
     {
         "System_MemoryAllocationFailed",
         {
-            { ELanguage::English,  "Failed to allocate game memory.\n\nPlease make sure that:\n\n- You meet the minimum system requirements (8 GB).\n- Your pagefile is configured with at least 4-8 GB of virtual memory." },
+            { ELanguage::English,  "Failed to allocate game memory.\n\nPlease make sure that:\n\n- You meet the minimum system requirements (8 GB).\n- Your page file is configured with at least 4-8 GB of virtual memory." },
             { ELanguage::Japanese, "" },
             { ELanguage::German,   "" },
             { ELanguage::French,   "" },

--- a/UnleashedRecomp/locale/locale.cpp
+++ b/UnleashedRecomp/locale/locale.cpp
@@ -704,6 +704,17 @@ std::unordered_map<std::string_view, std::unordered_map<ELanguage, std::string>>
         }
     },
     {
+        "System_MemoryAllocationFailed",
+        {
+            { ELanguage::English,  "Memory allocation failed blablabla enable your pagefile, ensure it's minimum 4 or 8 GB blablablabla" },
+            { ELanguage::Japanese, "" },
+            { ELanguage::German,   "" },
+            { ELanguage::French,   "" },
+            { ELanguage::Spanish,  "" },
+            { ELanguage::Italian,  "" }
+        }
+    },
+    {
         "Common_On",
         {
             { ELanguage::English,  "ON" },

--- a/UnleashedRecomp/main.cpp
+++ b/UnleashedRecomp/main.cpp
@@ -51,14 +51,20 @@ void HostStartup()
     CoInitializeEx(nullptr, COINIT_MULTITHREADED);
 #endif
 
-    g_userHeap.Init();
-
     hid::Init();
 }
 
 // Name inspired from nt's entry point
 void KiSystemStartup()
 {
+    if (g_memory.base == nullptr)
+    {
+        SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, GameWindow::GetTitle(), Localise("System_MemoryAllocationFailed").c_str(), GameWindow::s_pWindow);
+        std::_Exit(1);
+    }
+
+    g_userHeap.Init();
+
     const auto gameContent = XamMakeContent(XCONTENTTYPE_RESERVED, "Game");
     const auto updateContent = XamMakeContent(XCONTENTTYPE_RESERVED, "Update");
     XamRegisterContent(gameContent, GAME_INSTALL_DIRECTORY "/game");


### PR DESCRIPTION
Closes #953.

Requires proper English text and localization. Localization is needed because the installer can run perfectly fine until the game boots, and the user can select a different language at the start.