### PR TITLE
Fix line splitting issues from localization changes

### DIFF
--- a/UnleashedRecomp/locale/config_locale.cpp
+++ b/UnleashedRecomp/locale/config_locale.cpp
@@ -233,7 +233,7 @@ CONFIG_DEFINE_ENUM_LOCALE(EControllerIcons)
     {
         ELanguage::English,
         {
-            { EControllerIcons::Auto,        { "AUTO", "Auto : the game will determine which icons to use based on the current input device." } },
+            { EControllerIcons::Auto,        { "AUTO", "Auto: the game will determine which icons to use based on the current input device." } },
             { EControllerIcons::Xbox,        { "XBOX", "" } },
             { EControllerIcons::PlayStation, { "PLAYSTATION", "" } }
         }
@@ -407,7 +407,7 @@ CONFIG_DEFINE_LOCALE(EffectsVolume)
 CONFIG_DEFINE_LOCALE(MusicAttenuation)
 {
     { ELanguage::English,  { "Music Attenuation", "Fade out the game's music when external media is playing." } },
-    { ELanguage::Japanese, { "BGM[減衰:げんすい]", "[外部:がいぶ]メディアを\u200B[再生:さいせい]すると\u200Bゲームの\u200B[音楽:おんがく]を\u200Bフェードアウトします" } },
+    { ELanguage::Japanese, { "BGM[減衰:げんすい]", "[外部:がいぶ]メディアを\u200B[再生:さいせい]すると\u200Bゲームの\u200B[音楽:おんがく]を\u200Bフェードアウト\u200Bします" } },
     { ELanguage::German,   { "Musikdämpfung", "Stelle die Musik des Spiels stumm während externe Medien abgespielt werden." } },
     { ELanguage::French,   { "Atténuation audio", "Abaisse le volume des musiques du jeu lorsqu'un média externe est en cours de lecture." } },
     { ELanguage::Spanish,  { "Atenuación de música", "Atenúa la música del juego cuando un reproductor multimedia se encuentra activo." } },
@@ -508,7 +508,7 @@ CONFIG_DEFINE_LOCALE(BattleTheme)
 CONFIG_DEFINE_LOCALE(WindowSize)
 {
     { ELanguage::English,  { "Window Size", "Adjust the size of the game window in windowed mode." } },
-    { ELanguage::Japanese, { "ウィンドウサイズ", "ウィンドウモードでの\u200Bゲームの\u200Bウィンドウサイズを\u200B[調整:ちょうせい]できます" } },
+    { ELanguage::Japanese, { "ウィンドウサイズ", "ウィンドウ\u200Bモードでの\u200Bゲームの\u200Bウィンドウサイズを\u200B[調整:ちょうせい]できます" } },
     { ELanguage::German,   { "Fenstergröße", "Ändere die Größe des Spielfensters im Fenstermodus." } },
     { ELanguage::French,   { "Taille de la fenêtre", "Modifie la taille de la fenêtre de jeu en mode fenêtré." } },
     { ELanguage::Spanish,  { "Tamaño de ventana", "Ajusta el tamaño de la ventana de juego." } },

--- a/UnleashedRecomp/locale/locale.cpp
+++ b/UnleashedRecomp/locale/locale.cpp
@@ -366,7 +366,7 @@ std::unordered_map<std::string_view, std::unordered_map<ELanguage, std::string>>
             { ELanguage::English,  "Installation complete!\nThis project is brought to you by:" },
             { ELanguage::Japanese, "インストール[完了:かんりょう]！\nプロジェクト[制作:せいさく]：" },
             { ELanguage::German,   "Installation abgeschlossen!\nDieses Projekt wird präsentiert von:" },
-            { ELanguage::French,   "Installation terminée !\nCe projet vous est présenté par :" },
+            { ELanguage::French,   "Installation terminée !\nCe projet vous est présenté\npar :" },
             { ELanguage::Spanish,  "¡Instalación completada!\nEste proyecto ha sido posible gracias a:" },
             { ELanguage::Italian,  "Installazione completata!\nQuesto progetto è stato creato da:" }
         }

--- a/UnleashedRecomp/ui/imgui_utils.cpp
+++ b/UnleashedRecomp/ui/imgui_utils.cpp
@@ -510,6 +510,11 @@ std::vector<std::string> Split(const char* strStart, const ImFont* font, float f
                 if (*str == '\n')
                     str++;
 
+                if (strncmp(str, "\u200B", 3) == 0)
+                {
+                    str += 3;
+                }
+
                 lineStart = str;
                 continue;
             }


### PR DESCRIPTION
Fixes issues in the following locations (the pictures are pre-fix the text explains the fix):
![image](https://github.com/user-attachments/assets/00f32ade-fe29-49fa-b1ab-c3553d2d1b09)
Line is split in the middle of `します`, added Japanese line splitting guidance before it.

![image](https://github.com/user-attachments/assets/03d1a16c-0126-4510-960b-a095c292bfeb)
Line is split between `での`, to avoid cutting the particles in the middle a split guidance marker was added before `モード`.

![image](https://github.com/user-attachments/assets/836cd381-591a-4778-99ab-9d9d7a91e5ce)
An unnecessary empty line is inserted. The issue was alleviated by skipping over `\u200B` guidance markers just like `\n` if a line starts with one after the split logic happens.

![image](https://github.com/user-attachments/assets/3e888ed6-c8f9-4f05-bab1-ea0b9bd02ced)
French localization added an unnecessary space to the English localization here between the colon and `Auto`.

![image](https://github.com/user-attachments/assets/914b6e35-28f4-4b48-81b2-c501d059d4c9)
The colon is split into a different line in French after the necessary space before it was added. A manual line split was added before `par`.