### PR TITLE
Implement returning to title from installer menu

### DIFF
--- a/UnleashedRecomp/main.cpp
+++ b/UnleashedRecomp/main.cpp
@@ -333,7 +333,14 @@ int main(int argc, char *argv[])
 
         if (!InstallerWizard::Run(GAME_INSTALL_DIRECTORY, isGameInstalled && forceDLCInstaller))
         {
-            std::_Exit(0);
+            if (!forceDLCInstaller)
+            {
+                std::_Exit(0);
+            }
+            else
+            {
+                InstallerWizard::s_returnToTitle = true;
+            }
         }
     }
 

--- a/UnleashedRecomp/patches/misc_patches.cpp
+++ b/UnleashedRecomp/patches/misc_patches.cpp
@@ -1,5 +1,6 @@
 #include <api/SWA.h>
 #include <ui/game_window.h>
+#include <ui/installer_wizard.h>
 #include <user/achievement_manager.h>
 #include <user/persistent_storage_manager.h>
 #include <user/config.h>
@@ -83,7 +84,7 @@ PPC_FUNC(sub_825197C0)
 PPC_FUNC_IMPL(__imp__sub_82547DF0);
 PPC_FUNC(sub_82547DF0)
 {
-    if (Config::SkipIntroLogos)
+    if (Config::SkipIntroLogos || InstallerWizard::s_returnToTitle)
     {
         ctx.r4.u64 = 0;
         ctx.r5.u64 = 0;

--- a/UnleashedRecomp/ui/installer_wizard.h
+++ b/UnleashedRecomp/ui/installer_wizard.h
@@ -5,6 +5,7 @@
 struct InstallerWizard
 {
     static inline bool s_isVisible = false;
+    static inline bool s_returnToTitle = false;
 
     static void Init();
     static void Draw();


### PR DESCRIPTION
Allows the installer menu to return to title if the user revisits the installer from the title screen for missing DLC installation. Upon quitting the installer the game will return to the title menu, whilst skipping the intro logos.

Closes #706.