### PR TITLE
Fix compilation errors on latest Windows SDK version

### DIFF
--- a/UnleashedRecomp/CMakeLists.txt
+++ b/UnleashedRecomp/CMakeLists.txt
@@ -358,6 +358,7 @@ if (WIN32)
         Shcore
         Synchronization
         winmm
+        windowsapp
     )
 endif()
 


### PR DESCRIPTION
```
>------ Build started: Project: CMakeLists, Configuration: Debug ------
  [1/1] Linking CXX executable UnleashedRecomp\UnleashedRecomp.exe
  FAILED: UnleashedRecomp/UnleashedRecomp.exe 
  C:\WINDOWS\system32\cmd.exe /C "cd . && "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" -E vs_link_exe --msvc-ver=1944 --intdir=UnleashedRecomp\CMakeFiles\UnleashedRecomp.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MICROS~1\2022\COMMUN~1\VC\Tools\Llvm\x64\bin\lld-link.exe /nologo @CMakeFiles\UnleashedRecomp.rsp  /out:UnleashedRecomp\UnleashedRecomp.exe /implib:UnleashedRecomp\UnleashedRecomp.lib /pdb:UnleashedRecomp\UnleashedRecomp.pdb /version:0.0 /machine:x64 /debug /INCREMENTAL /subsystem:console && C:\WINDOWS\system32\cmd.exe /C "cd /D C:\Users\DeaThProj\source\repos\UnleashedRecomp\out\build\x64-Clang-Debug\UnleashedRecomp && C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -noprofile -executionpolicy Bypass -file C:/Users/DeaThProj/source/repos/UnleashedRecomp/thirdparty/vcpkg/scripts/buildsystems/msbuild/applocal.ps1 -targetBinary C:/Users/DeaThProj/source/repos/UnleashedRecomp/out/build/x64-Clang-Debug/UnleashedRecomp/UnleashedRecomp.exe -installedDir C:/Users/DeaThProj/source/repos/UnleashedRecomp/out/build/x64-Clang-Debug/vcpkg_installed/x64-windows-static/debug/bin -OutVariable out && cd /D C:\Users\DeaThProj\source\repos\UnleashedRecomp\out\build\x64-Clang-Debug\UnleashedRecomp && "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" -E copy C:/Users/DeaThProj/source/repos/UnleashedRecomp/out/build/x64-Clang-Debug/vcpkg_installed/x64-windows-static/bin/D3D12Core.dll C:/Users/DeaThProj/source/repos/UnleashedRecomp/out/build/x64-Clang-Debug/UnleashedRecomp/D3D12 && "C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin\cmake.exe" -E copy C:/Users/DeaThProj/source/repos/UnleashedRecomp/out/build/x64-Clang-Debug/vcpkg_installed/x64-windows-static/debug/bin/d3d12SDKLayers.dll C:/Users/DeaThProj/source/repos/UnleashedRecomp/out/build/x64-Clang-Debug/UnleashedRecomp/D3D12""
  LINK Pass 1: command "C:\PROGRA~1\MICROS~1\2022\COMMUN~1\VC\Tools\Llvm\x64\bin\lld-link.exe /nologo @CMakeFiles\UnleashedRecomp.rsp /out:UnleashedRecomp\UnleashedRecomp.exe /implib:UnleashedRecomp\UnleashedRecomp.lib /pdb:UnleashedRecomp\UnleashedRecomp.pdb /version:0.0 /machine:x64 /debug /INCREMENTAL /subsystem:console /MANIFEST /MANIFESTFILE:UnleashedRecomp\CMakeFiles\UnleashedRecomp.dir/intermediate.manifest UnleashedRecomp\CMakeFiles\UnleashedRecomp.dir/manifest.res" failed (exit code 1) with the following output:
C:\Users\DeaThProj\source\repos\UnleashedRecomp\out\build\x64-Clang-Debug\UnleashedRecomp\lld-link : warning : xxhash.lib(xxhash.c.obj): locally defined symbol imported: _wassert (defined in libucrtd.lib(assert.obj)) [LNK4217]
C:\Users\DeaThProj\source\repos\UnleashedRecomp\out\build\x64-Clang-Debug\UnleashedRecomp\lld-link : warning : xxhash.lib(xxhash.c.obj): locally defined symbol imported: malloc (defined in libucrtd.lib(malloc.obj)) [LNK4217]
C:\Users\DeaThProj\source\repos\UnleashedRecomp\out\build\x64-Clang-Debug\UnleashedRecomp\lld-link : warning : xxhash.lib(xxhash.c.obj): locally defined symbol imported: free (defined in libucrtd.lib(free.obj)) [LNK4217]
C:\Users\DeaThProj\source\repos\UnleashedRecomp\out\build\x64-Clang-Debug\UnleashedRecomp\lld-link : error : undefined symbol: WINRT_IMPL_RoOriginateLanguageException
  >>> referenced by C:\Program Files (x86)\Windows Kits\10\include\10.0.26100.0\cppwinrt\winrt\base.h:4840
  >>>               UnleashedRecomp\CMakeFiles\UnleashedRecomp.dir\os\win32\media_win32.cpp.obj:(private: void __cdecl winrt::hresult_error::originate(struct winrt::hresult, void *, struct winrt::impl::slim_source_location const &))
  
C:\Users\DeaThProj\source\repos\UnleashedRecomp\out\build\x64-Clang-Debug\UnleashedRecomp\lld-link : error : undefined symbol: WINRT_IMPL_RoGetActivationFactory
  >>> referenced by C:\Program Files (x86)\Windows Kits\10\include\10.0.26100.0\cppwinrt\winrt\base.h:6092
  >>>               UnleashedRecomp\CMakeFiles\UnleashedRecomp.dir\os\win32\media_win32.cpp.obj:(struct winrt::hresult __cdecl winrt::impl::get_runtime_activation_factory_impl<0>(struct winrt::param::hstring const &, struct winrt::guid const &, void **))
  >>> referenced by C:\Program Files (x86)\Windows Kits\10\include\10.0.26100.0\cppwinrt\winrt\base.h:6105
  >>>               UnleashedRecomp\CMakeFiles\UnleashedRecomp.dir\os\win32\media_win32.cpp.obj:(struct winrt::hresult __cdecl winrt::impl::get_runtime_activation_factory_impl<0>(struct winrt::param::hstring const &, struct winrt::guid const &, void **))
  
  ninja: build stopped: subcommand failed.
```
Fixes this build issue from latest Windows SDK.