### PR TITLE
Graphics API Selection within In-Game Settings

### DIFF
--- a/UnleashedRecomp/gpu/video.h
+++ b/UnleashedRecomp/gpu/video.h
@@ -5,6 +5,7 @@
 //#define PSO_CACHING_CLEANUP
 
 #include <plume_render_interface.h>
+#include <user/config.h>
 
 #define D3DCLEAR_TARGET  0x1
 #define D3DCLEAR_ZBUFFER 0x10
@@ -24,6 +25,8 @@ struct Video
     static void StartPipelinePrecompilation();
     static void WaitForGPU();
     static void ComputeViewportDimensions();
+    static EGraphicsAPI GetCurrentGraphicsAPI();
+    static bool IsCurrentAPIChosenByAuto();
 };
 
 struct GuestSamplerState

--- a/UnleashedRecomp/locale/config_locale.cpp
+++ b/UnleashedRecomp/locale/config_locale.cpp
@@ -527,6 +527,82 @@ CONFIG_DEFINE_LOCALE(Monitor)
 };
 
 // Japanese Notes: This localization should include furigana.
+CONFIG_DEFINE_LOCALE(GraphicsAPI)
+{
+    { ELanguage::English,  { "Graphics API", "Change the graphics API used for rendering. \n\nWARNING: Changing graphics api requires game restart" } },
+    { ELanguage::Japanese, { "グラフィックAPI", "レンダリングに[使用:しよう]するグラフィックAPIを[変更:へんこう]します。\n\n[警告:けいこく]: グラフィックAPIの[変更:へんこう]にはゲームの[再起動:さいきどう]が[必要:ひつよう]です" } },
+    { ELanguage::German,   { "Grafik-API", "Ändere die Grafik-API für das Rendering. \n\nWARNUNG: Das Ändern der Grafik-API erfordert einen Neustart des Spiels" } },
+    { ELanguage::French,   { "API graphique", "Modifie l'API graphique utilisée pour le rendu. \n\nATTENTION : Changer l'API graphique nécessite un redémarrage du jeu" } },
+    { ELanguage::Spanish,  { "API de gráficos", "Cambia la API de gráficos utilizada para el renderizado. \n\nADVERTENCIA: Cambiar la API de gráficos requiere reiniciar el juego" } },
+    { ELanguage::Italian,  { "API grafica", "Modifica l'API grafica utilizzata per il rendering. \n\nATTENZIONE: Cambiare l'API grafica richiede il riavvio del gioco" } }
+};
+
+// Japanese Notes: This localization should include furigana in its description.
+CONFIG_DEFINE_ENUM_LOCALE(EGraphicsAPI)
+{
+    {
+        ELanguage::English,
+        {
+            { EGraphicsAPI::Auto, { "AUTO", "Automatically selects the best available graphics API for your system." } },
+#ifdef UNLEASHED_RECOMP_D3D12
+            { EGraphicsAPI::D3D12, { "DX12", "use Microsoft's DirectX 12 API for graphics rendering." } },
+#endif
+            { EGraphicsAPI::Vulkan, { "VULKAN", "use Khronos Group's Vulkan API for graphics rendering." } }
+        }
+    },
+    {
+        ELanguage::Japanese,
+        {
+            { EGraphicsAPI::Auto, { "自動", "[自動:じどう]: [最適:さいてき]なグラフィックAPIを\u200B[自動的:じどうてき]に\u200B[選択:せんたく]します" } },
+#ifdef UNLEASHED_RECOMP_D3D12
+            { EGraphicsAPI::D3D12, { "DX12", "Microsoft の DirectX 12 API を\u200B[使用:しよう]してレンダリングします" } },
+#endif
+            { EGraphicsAPI::Vulkan, { "VULKAN", "Khronos Group の Vulkan API を\u200B[使用:しよう]してレンダリングします" } }
+        }
+    },
+    {
+        ELanguage::German,
+        {
+            { EGraphicsAPI::Auto, { "AUTO", "Wählt automatisch die beste verfügbare Grafik-API aus." } },
+#ifdef UNLEASHED_RECOMP_D3D12
+            { EGraphicsAPI::D3D12, { "DX12", "Verwendet Microsofts DirectX 12 API für das Rendering." } },
+#endif
+            { EGraphicsAPI::Vulkan, { "VULKAN", "Verwendet die Khronos Group's Vulkan API für das Rendering." } }
+        }
+    },
+    {
+        ELanguage::French,
+        {
+            { EGraphicsAPI::Auto, { "AUTO", "sélectionne automatiquement la meilleure API graphique disponible." } },
+#ifdef UNLEASHED_RECOMP_D3D12
+            { EGraphicsAPI::D3D12, { "DX12", "utilise l'API DirectX 12 de Microsoft pour le rendu." } },
+#endif
+            { EGraphicsAPI::Vulkan, { "VULKAN", "utilise l'API Vulkan du Khronos Group pour le rendu." } }
+        }
+    },
+    {
+        ELanguage::Spanish,
+        {
+            { EGraphicsAPI::Auto, { "AUTO", "selecciona automáticamente la mejor API de gráficos disponible." } },
+#ifdef UNLEASHED_RECOMP_D3D12
+            { EGraphicsAPI::D3D12, { "DX12", "utiliza la API DirectX 12 de Microsoft para el renderizado." } },
+#endif
+            { EGraphicsAPI::Vulkan, { "VULKAN", "utiliza la API Vulkan del Khronos Group para el renderizado." } }
+        }
+    },
+    {
+        ELanguage::Italian,
+        {
+            { EGraphicsAPI::Auto, { "AUTO", "seleziona automaticamente la migliore API grafica disponibile." } },
+#ifdef UNLEASHED_RECOMP_D3D12
+            { EGraphicsAPI::D3D12, { "DX12", "utilizza l'API DirectX 12 di Microsoft per il rendering." } },
+#endif
+            { EGraphicsAPI::Vulkan, { "VULKAN", "utilizza l'API Vulkan del Khronos Group per il rendering." } }
+        }
+    }
+};
+
+// Japanese Notes: This localization should include furigana.
 CONFIG_DEFINE_LOCALE(AspectRatio)
 {
     { ELanguage::English,  { "Aspect Ratio", "Change the aspect ratio." } },

--- a/UnleashedRecomp/ui/options_menu.cpp
+++ b/UnleashedRecomp/ui/options_menu.cpp
@@ -1271,6 +1271,7 @@ static void DrawConfigOptions()
             DrawConfigOption(rowCount++, yOffset, &Config::AspectRatio, true);
             DrawConfigOption(rowCount++, yOffset, &Config::ResolutionScale, true, nullptr, 0.25f, 1.0f, 2.0f);
             DrawConfigOption(rowCount++, yOffset, &Config::Fullscreen, true);
+            DrawConfigOption(rowCount++, yOffset, &Config::GraphicsAPI, true);
             DrawConfigOption(rowCount++, yOffset, &Config::VSync, true);
             DrawConfigOption(rowCount++, yOffset, &Config::FPS, true, nullptr, FPS_MIN, 120, FPS_MAX);
             DrawConfigOption(rowCount++, yOffset, &Config::Brightness, true);

--- a/UnleashedRecomp/user/config.h
+++ b/UnleashedRecomp/user/config.h
@@ -200,6 +200,13 @@ public:
     void GetLocaleStrings(std::vector<std::string_view>& localeStrings) const override;
     void SnapToNearestAccessibleValue(bool searchUp) override;
 
+private:
+    // Graphics API dynamic text
+    bool ShouldShowCurrentAPI() const;
+    std::string GetCurrentAPIName(const ELanguage* languages, CONFIG_ENUM_LOCALE(T)* locale) const;
+    std::string GetCurrentAPIText(ELanguage language, const std::string& apiName) const;
+
+public:
     operator T() const
     {
         return Value;
@@ -219,6 +226,7 @@ public:
 #define CONFIG_DEFINE_LOCALISED(section, type, name, defaultValue)              CONFIG_DECLARE(type, name)
 #define CONFIG_DEFINE_ENUM(section, type, name, defaultValue)                   CONFIG_DECLARE(type, name)
 #define CONFIG_DEFINE_ENUM_LOCALISED(section, type, name, defaultValue)         CONFIG_DECLARE(type, name)
+#define CONFIG_DEFINE_ENUM_LOCALISED_HIDDEN(section, type, name, defaultValue)  CONFIG_DECLARE_HIDDEN(type, name)
 
 class Config
 {

--- a/UnleashedRecomp/user/config_def.h
+++ b/UnleashedRecomp/user/config_def.h
@@ -47,7 +47,12 @@ CONFIG_DEFINE_LOCALISED("Audio", bool, MusicAttenuation, false);
 CONFIG_DEFINE_LOCALISED("Audio", bool, BattleTheme, true);
 
 CONFIG_DEFINE("Video", std::string, GraphicsDevice, "");
-CONFIG_DEFINE_ENUM("Video", EGraphicsAPI, GraphicsAPI, EGraphicsAPI::Auto);
+#ifdef UNLEASHED_RECOMP_D3D12
+CONFIG_DEFINE_ENUM_LOCALISED("Video", EGraphicsAPI, GraphicsAPI, EGraphicsAPI::Auto);
+#else
+// Hide Graphics API setting for Vulkan-only builds
+CONFIG_DEFINE_ENUM_LOCALISED_HIDDEN("Video", EGraphicsAPI, GraphicsAPI, EGraphicsAPI::Vulkan);
+#endif
 CONFIG_DEFINE("Video", int32_t, WindowX, WINDOWPOS_CENTRED);
 CONFIG_DEFINE("Video", int32_t, WindowY, WINDOWPOS_CENTRED);
 CONFIG_DEFINE_LOCALISED("Video", int32_t, WindowSize, -1);


### PR DESCRIPTION
Originally: To change between DirectX 12 and Vulkan API: you'd need to go to `config.toml`'s GraphicsAPI to either D3D12 or Vulkan. Now, you can choose Graphics APIs directly through the In-Game Video Settings, addressing https://github.com/hedge-dev/UnleashedRecomp/issues/501

<img width="1236" height="563" alt="image" src="https://github.com/user-attachments/assets/847c6624-8dfb-41ec-8139-4941ff143aa1" />

If Auto is selected (assuming you selected Auto and you restarted the game): the "Currently Using" text wll be showing if it's DirectX 12 (DX12) or Vulkan (VULKAN) renderer, this should make it easier to troubleshoot without needing to press [F1].

however: there are three things that needs to be updated and tested before this PR to be merged

- [ ] Ensure that the Graphics API UI should NOT be shown when using Linux&MacOS/Vulkan only build
    - Right now: I have not tested the Linux version, and I don't have access to the Mac device at the moment
- [ ] Localized the title and description across all languages
   - right now: it's very "Google Translated" in a placeholdery way beyond English text (that can be updated, too!), those needs to be replace with proper localized text
 - [ ] Thumbnail image, with DirectX 12 and Vulkan logos (optional)