### PR TITLE
Update to Flatpak runtime 24.08

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-  
+
 jobs:
   build-linux:
     name: Build Linux
@@ -38,7 +38,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: ccache-${{ runner.os }}-${{ matrix.preset }}
-  
+
       - name: Cache vcpkg
         uses: actions/cache@v4
         with:
@@ -119,7 +119,7 @@ jobs:
         run: |
           choco install ninja
           Remove-Item -Path "C:\ProgramData\Chocolatey\bin\ccache.exe" -Force -ErrorAction SilentlyContinue
-      
+
       - name: Configure Developer Command Prompt
         uses: ilammy/msvc-dev-cmd@v1
 
@@ -134,7 +134,7 @@ jobs:
 
       - name: Build Project
         run: cmake --build .\out\build\${{ env.CMAKE_PRESET }} --target UnleashedRecomp
-      
+
       - name: Pack Release
         run: |
           New-Item -ItemType Directory -Path .\release
@@ -162,8 +162,6 @@ jobs:
     runs-on: ubuntu-24.04
     env:
       FLATPAK_ID: io.github.hedge_dev.unleashedrecomp
-      FREEDESKTOP_VERSION: 23.08
-      LLVM_VERSION: 18
 
     steps:
       - name: Checkout Repository
@@ -190,13 +188,11 @@ jobs:
           key: ccache-${{ runner.os }}
 
       - name: Prepare Project
-        run: cp ./private/* ./UnleashedRecompLib/private  
+        run: cp ./private/* ./UnleashedRecompLib/private
 
       - name: Prepare Flatpak
         run: |
           flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-          flatpak --user install -y flathub org.freedesktop.Sdk//${{ env.FREEDESKTOP_VERSION }}
-          flatpak --user install -y flathub org.freedesktop.Sdk.Extension.llvm${{ env.LLVM_VERSION }}//${{ env.FREEDESKTOP_VERSION }}
 
       - name: Build Flatpak
         run: |

--- a/flatpak/io.github.hedge_dev.unleashedrecomp.json
+++ b/flatpak/io.github.hedge_dev.unleashedrecomp.json
@@ -1,7 +1,7 @@
 {
   "id": "io.github.hedge_dev.unleashedrecomp",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "23.08",
+  "runtime-version": "24.08",
   "sdk": "org.freedesktop.Sdk",
   "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.llvm18" ],
   "finish-args": [


### PR DESCRIPTION
Runtime 23.08 is EOL since this month.

~~Update LLVM from 18 to 20 at the same time.~~

~~I uses LLVM 20, even if a LLVM 21 SDK is availaibe, since that is the newest version available on the GitLab runners, which makes it easy to keep the Flatpak & Linux builds in sync. I can split out the LLVM 20 update into a new PR if you want.~~
