### PR TITLE
Update runtime and SDK versions in JSON config

### DIFF
--- a/flatpak/io.github.hedge_dev.unleashedrecomp.json
+++ b/flatpak/io.github.hedge_dev.unleashedrecomp.json
@@ -1,9 +1,9 @@
 {
   "id": "io.github.hedge_dev.unleashedrecomp",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "23.08",
+  "runtime-version": "25.08",
   "sdk": "org.freedesktop.Sdk",
-  "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.llvm18" ],
+  "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.llvm21" ],
   "finish-args": [
     "--share=network",
     "--socket=wayland",
@@ -35,8 +35,8 @@
         }
       ],
       "build-options": {
-        "append-path": "/usr/lib/sdk/llvm18/bin",
-        "prepend-ld-library-path": "/usr/lib/sdk/llvm18/lib",
+        "append-path": "/usr/lib/sdk/llvm21/bin",
+        "prepend-ld-library-path": "/usr/lib/sdk/llvm21/lib",
         "build-args": [
           "--share=network"
         ]


### PR DESCRIPTION
I have updated flatpak to use the 25.08 version and the sdk version because the old one is end of life.