### PR TITLE
Fix Window Size option crashing on Steam Deck Desktop Mode

### DIFF
--- a/UnleashedRecomp/ui/options_menu.cpp
+++ b/UnleashedRecomp/ui/options_menu.cpp
@@ -1255,9 +1255,14 @@ static void DrawConfigOptions()
 
         case 3: // VIDEO
         {
-            DrawConfigOption(rowCount++, yOffset, &Config::WindowSize,
-                !Config::Fullscreen, &Localise("Options_Desc_NotAvailableFullscreen"),
-                0, 0, (int32_t)GameWindow::GetDisplayModes().size() - 1, false);
+            auto displayModeCount = (int32_t)GameWindow::GetDisplayModes().size();
+            auto canChangeWindowSize = !Config::Fullscreen && displayModeCount > 1;
+            auto windowSizeReason = &Localise("Options_Desc_NotAvailableFullscreen");
+            
+            if (!Config::Fullscreen && displayModeCount <= 1)
+                windowSizeReason = &Localise("Options_Desc_NotAvailableHardware");
+
+            DrawConfigOption(rowCount++, yOffset, &Config::WindowSize, canChangeWindowSize, windowSizeReason, 0, 0, displayModeCount - 1, false);
 
             auto displayCount = GameWindow::GetDisplayCount();
             auto canChangeMonitor = Config::Fullscreen && displayCount > 1;


### PR DESCRIPTION
Implements a safeguard for editing Window Size incase a display doesn't have more than one available resolutions (such as the Steam Deck's desktop mode without an external display).

Closes #343.