### PR TITLE
Implement fix for Skyscraper Scamper Act 1 (Day) building drawing incorrectly

### DIFF
--- a/UnleashedRecomp/patches/video_patches.cpp
+++ b/UnleashedRecomp/patches/video_patches.cpp
@@ -141,3 +141,26 @@ PPC_FUNC(sub_82E38650)
 
     __imp__sub_82E38650(ctx, base);
 }
+
+// Part of the building right after exiting the tunnel after the drift turn after the first checkpoint
+// is placed on an transparent mesh slot. This somehow works. Except on high-performance Windows machines,
+// hinting at the fact that its related to some scheduler issue with the asset loading.
+// We can fix it by detecting the asset runtime, and combining the opaque and transparent mesh slots by
+// using the name offset field on the mesh group as an additional value in the array and shifting the
+// opaque mesh slot's offset back by one and then correcting the offset table for this change.
+
+// Hedgehog::Mirage::CTerrainModelData::Make
+PPC_FUNC_IMPL(__imp__sub_82E39618);
+PPC_FUNC(sub_82E39618)
+{
+    if (ctx.r5.u32 == 0xA470 && XXH3_64bits(base + ctx.r4.u32, ctx.r5.u32) == 0x8474C14C113626D2)
+    {
+        PPC_STORE_U32(ctx.r4.u32 + 0x28, 7);
+        PPC_STORE_U32(ctx.r4.u32 + 0x2C, 0x38);
+        PPC_STORE_U32(ctx.r4.u32 + 0x30, 0);
+        PPC_STORE_U32(ctx.r4.u32 + 0x50, 0x88C4);
+        PPC_STORE_U32(ctx.r4.u32 + 0xA438, 0x38);
+    }
+
+    __imp__sub_82E39618(ctx, base);
+}


### PR DESCRIPTION
Modifies the asset of the building at runtime (whilst checking for hash to not cause problems with mods) so that all the meshes use the opaque mesh slot.

To achieve this the mesh group's [name offset](https://github.com/hedge-dev/SharpNeedle/blob/master/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/ModelData/MeshGroup.cs#L68) parameter is reused as it happens to be just before where the offset for the opaque meshes point to.

As such we can write the value from the transparent mesh slot there and adjust the offset, the mesh counts and the offset table to combine the two mesh slots into the opaque slot.

Fixes #478.