### PR TITLE
Try updating Freedesktop runtime to 25.08

### DIFF
--- a/flatpak/io.github.hedge_dev.unleashedrecomp.json
+++ b/flatpak/io.github.hedge_dev.unleashedrecomp.json
@@ -20,7 +20,7 @@
       "buildsystem": "simple",
       "build-commands": [
         "mkdir -p /usr/lib/sdk/llvm18",
-        "tar clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar --strip-components=1 -C /usr/lib/sdk/llvm18/"
+        "tar -xf clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar --strip-components=1 -C /usr/lib/sdk/llvm18/"
       ],
       "sources": [
         {

--- a/flatpak/io.github.hedge_dev.unleashedrecomp.json
+++ b/flatpak/io.github.hedge_dev.unleashedrecomp.json
@@ -19,14 +19,24 @@
       "name": "llvm",
       "buildsystem": "simple",
       "build-commands": [
-        "mkdir -p /usr/lib/sdk/llvm18",
-        "tar -xf clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar --strip-components=1 -C /usr/lib/sdk/llvm18/"
+        "mkdir -p /usr/lib/sdk/llvm18 llvm/extracted",
+        "tar -xJf llvm/*.tar.xz -C llvm/extracted",
+        "tar -xf  llvm/extracted/*.tar --strip-components=1 -C /usr/lib/sdk/llvm18/"
       ],
       "sources": [
         {
-          "type": "archive",
+          "type": "file",
           "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz",
-          "sha256": "54ec30358afcc9fb8aa74307db3046f5187f9fb89fb37064cdde906e062ebf36"
+          "sha256": "54ec30358afcc9fb8aa74307db3046f5187f9fb89fb37064cdde906e062ebf36",
+          "dest": "llvm",
+          "only-arches": ["x86_64"]
+        },
+        {
+          "type": "file",
+          "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-aarch64-linux-gnu.tar.xz",
+          "sha256": "dcaa1bebbfbb86953fdfbdc7f938800229f75ad26c5c9375ef242edad737d999",
+          "dest": "llvm",
+          "only-arches": ["aarch64"]
         }
       ],
       "cleanup": [ "*" ] 

--- a/flatpak/io.github.hedge_dev.unleashedrecomp.json
+++ b/flatpak/io.github.hedge_dev.unleashedrecomp.json
@@ -3,7 +3,7 @@
   "runtime": "org.freedesktop.Platform",
   "runtime-version": "25.08",
   "sdk": "org.freedesktop.Sdk",
-  "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.llvm18" ],
+  "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.llvm20" ],
   "finish-args": [
     "--share=network",
     "--socket=wayland",
@@ -35,8 +35,8 @@
         }
       ],
       "build-options": {
-        "append-path": "/usr/lib/sdk/llvm18/bin",
-        "prepend-ld-library-path": "/usr/lib/sdk/llvm18/lib",
+        "append-path": "/usr/lib/sdk/llvm20/bin",
+        "prepend-ld-library-path": "/usr/lib/sdk/llvm20/lib",
         "build-args": [
           "--share=network"
         ]

--- a/flatpak/io.github.hedge_dev.unleashedrecomp.json
+++ b/flatpak/io.github.hedge_dev.unleashedrecomp.json
@@ -1,7 +1,7 @@
 {
   "id": "io.github.hedge_dev.unleashedrecomp",
   "runtime": "org.freedesktop.Platform",
-  "runtime-version": "24.08",
+  "runtime-version": "25.08",
   "sdk": "org.freedesktop.Sdk",
   "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.llvm18" ],
   "finish-args": [

--- a/flatpak/io.github.hedge_dev.unleashedrecomp.json
+++ b/flatpak/io.github.hedge_dev.unleashedrecomp.json
@@ -3,7 +3,6 @@
   "runtime": "org.freedesktop.Platform",
   "runtime-version": "25.08",
   "sdk": "org.freedesktop.Sdk",
-  "sdk-extensions" : [ "org.freedesktop.Sdk.Extension.llvm20" ],
   "finish-args": [
     "--share=network",
     "--socket=wayland",
@@ -16,6 +15,22 @@
     "--filesystem=/mnt"
   ],
   "modules": [
+    {
+      "name": "llvm",
+      "buildsystem": "simple",
+      "build-commands": [
+        "mkdir -p /usr/lib/sdk/llvm18",
+        "tar clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar --strip-components=1 -C /usr/lib/sdk/llvm18/"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz",
+          "sha256": "54ec30358afcc9fb8aa74307db3046f5187f9fb89fb37064cdde906e062ebf36"
+        }
+      ],
+      "cleanup": [ "*" ] 
+    },
     {
       "name": "UnleashedRecomp",
       "buildsystem": "simple",
@@ -35,8 +50,8 @@
         }
       ],
       "build-options": {
-        "append-path": "/usr/lib/sdk/llvm20/bin",
-        "prepend-ld-library-path": "/usr/lib/sdk/llvm20/lib",
+        "append-path": "/usr/lib/sdk/llvm18/bin",
+        "prepend-ld-library-path": "/usr/lib/sdk/llvm18/lib",
         "build-args": [
           "--share=network"
         ]


### PR DESCRIPTION
Updates freedesktop to 25.08
Also uses llvm18 as a separate module instead of an sdk extension because it is no longer supported
in the newer freedesktop, and afaik UnleashedRecomp may have issues with llvm20