### PR TITLE
Add sound libs for Linux in building doc

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -39,11 +39,11 @@ In the installer, you must select the following **Workloads** and **Individual c
 ### Linux
 The following command will install the required dependencies on a distro that uses `apt` (such as Debian-based distros).
 ```bash
-sudo apt install autoconf automake libtool pkg-config curl cmake ninja-build clang clang-tools libgtk-3-dev
+sudo apt install autoconf automake libtool pkg-config curl cmake ninja-build clang clang-tools libgtk-3-dev libasound2-dev libpulse-dev libpipewire-0.3-dev
 ```
 The following command will install the required dependencies on a distro that uses `pacman` (such as Arch-based distros).
 ```bash
-sudo pacman -S base-devel ninja lld clang gtk3
+sudo pacman -S base-devel ninja lld clang gtk3 alsa-lib libpulse pipewire
 ```
 You can also find the equivalent packages for your preferred distro.
 


### PR DESCRIPTION
There was a PR (#1527) for adding sound libs to fix the sound on Linux CI, but I noticed those libs weren't there in the docs to build from source so just adding them here.